### PR TITLE
Ignore Index

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -91,6 +91,7 @@ module.exports = grammar({
     keyword_is: _ => make_keyword("is"),
     keyword_not: _ => make_keyword("not"),
     keyword_force: _ => make_keyword("force"),
+    keyword_ignore: _ => make_keyword("ignore"),
     keyword_using: _ => make_keyword("using"),
     keyword_use: _ => make_keyword("use"),
     keyword_index: _ => make_keyword("index"),
@@ -1217,6 +1218,7 @@ module.exports = grammar({
       choice(
         $.keyword_force,
         $.keyword_use,
+        $.keyword_ignore,
       ),
       $.keyword_index,
       optional(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -246,6 +246,10 @@
       "type": "PATTERN",
       "value": "force|FORCE"
     },
+    "keyword_ignore": {
+      "type": "PATTERN",
+      "value": "ignore|IGNORE"
+    },
     "keyword_using": {
       "type": "PATTERN",
       "value": "using|USING"
@@ -5182,6 +5186,10 @@
             {
               "type": "SYMBOL",
               "name": "keyword_use"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_ignore"
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2382,6 +2382,10 @@
           "named": true
         },
         {
+          "type": "keyword_ignore",
+          "named": true
+        },
+        {
           "type": "keyword_index",
           "named": true
         },
@@ -4427,6 +4431,10 @@
   },
   {
     "type": "keyword_if",
+    "named": true
+  },
+  {
+    "type": "keyword_ignore",
     "named": true
   },
   {

--- a/test/corpus/group_by.txt
+++ b/test/corpus/group_by.txt
@@ -1,0 +1,165 @@
+================================================================================
+Group by
+================================================================================
+
+SELECT other_id, COUNT(name)
+FROM my_table
+GROUP BY other_id
+HAVING other_id > 10;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+            name: (identifier)))
+        (term
+          value: (count
+            name: (identifier)
+            parameter: (field
+              name: (identifier))))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (group_by
+        (keyword_group)
+        (keyword_by)
+        (expression_list
+          (field
+            name: (identifier)))
+        (keyword_having)
+        (predicate
+          left: (field
+            name: (identifier))
+          right: (literal))))))
+
+================================================================================
+Group by numbered alias
+================================================================================
+
+SELECT other_id, COUNT(name)
+FROM my_table
+GROUP BY 1
+HAVING other_id > 10;
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+            name: (identifier)))
+        (term
+          value: (count
+            name: (identifier)
+            parameter: (field
+              name: (identifier))))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (group_by
+        (keyword_group)
+        (keyword_by)
+        (expression_list
+          (literal))
+        (keyword_having)
+        (predicate
+          left: (field
+            name: (identifier))
+          right: (literal))))))
+
+================================================================================
+Group by with mixed list
+================================================================================
+
+SELECT other_id, other_col, COUNT(name)
+FROM my_table
+GROUP BY 1, other_col
+HAVING other_id > 10;
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+            name: (identifier)))
+        (term
+          value: (field
+            name: (identifier)))
+        (term
+          value: (count
+            name: (identifier)
+            parameter: (field
+              name: (identifier))))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (group_by
+        (keyword_group)
+        (keyword_by)
+        (expression_list
+          (literal)
+          (field
+            name: (identifier)))
+        (keyword_having)
+        (predicate
+          left: (field
+            name: (identifier))
+          right: (literal))))))
+
+================================================================================
+Having with count function
+================================================================================
+
+SELECT other_id, COUNT(name)
+FROM my_table
+GROUP BY other_id
+HAVING COUNT(*) = 2;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (field
+            (identifier)))
+        (term
+          (count
+            (identifier)
+            (field
+              (identifier))))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier)))
+      (group_by
+        (keyword_group)
+        (keyword_by)
+        (expression_list
+          (field
+            (identifier)))
+        (keyword_having)
+        (predicate
+          (count
+            (identifier)
+            (all_fields))
+          (literal))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -244,14 +244,20 @@ WHERE id IS NOT NULL
         (where_expression
           (predicate
             left: (predicate
-              left: (field name: (identifier))
-              operator: (is_not (keyword_is) (keyword_not))
-              right: (literal (keyword_null)))
+              left: (field
+                name: (identifier))
+              operator: (is_not
+                (keyword_is)
+                (keyword_not))
+              right: (literal
+                (keyword_null)))
             operator: (keyword_and)
             right: (predicate
-              left: (field name: (identifier))
+              left: (field
+                name: (identifier))
               operator: (keyword_is)
-              right: (literal (keyword_null)))))))))
+              right: (literal
+                (keyword_null)))))))))
 
 ================================================================================
 Simple select with aliased table and column name using double quotes
@@ -927,130 +933,6 @@ FROM my_table;
       (relation
         (table_reference
           name: (identifier))))))
-
-================================================================================
-Group by
-================================================================================
-
-SELECT other_id, COUNT(name)
-FROM my_table
-GROUP BY other_id
-HAVING other_id > 10;
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          value: (field
-            name: (identifier)))
-        (term
-          value: (count
-            name: (identifier)
-            parameter: (field
-              name: (identifier))))))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier)))
-      (group_by
-        (keyword_group)
-        (keyword_by)
-        (expression_list
-          (field
-            name: (identifier)))
-        (keyword_having)
-        (predicate
-          left: (field
-            name: (identifier))
-          right: (literal))))))
-
-================================================================================
-Group by numbered alias
-================================================================================
-
-SELECT other_id, COUNT(name)
-FROM my_table
-GROUP BY 1
-HAVING other_id > 10;
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          value: (field
-            name: (identifier)))
-        (term
-          value: (count
-            name: (identifier)
-            parameter: (field
-              name: (identifier))))))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier)))
-      (group_by
-        (keyword_group)
-        (keyword_by)
-        (expression_list
-          (literal))
-        (keyword_having)
-        (predicate
-          left: (field
-            name: (identifier))
-          right: (literal))))))
-
-================================================================================
-Group by with mixed list
-================================================================================
-
-SELECT other_id, other_col, COUNT(name)
-FROM my_table
-GROUP BY 1, other_col
-HAVING other_id > 10;
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          value: (field
-            name: (identifier)))
-        (term
-          value: (field
-            name: (identifier)))
-        (term
-          value: (count
-            name: (identifier)
-            parameter: (field
-              name: (identifier))))))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier)))
-      (group_by
-        (keyword_group)
-        (keyword_by)
-        (expression_list
-          (literal)
-          (field
-            name: (identifier)))
-        (keyword_having)
-        (predicate
-          left: (field
-            name: (identifier))
-          right: (literal))))))
 
 ================================================================================
 Joins
@@ -2492,20 +2374,20 @@ SELECT array[1, 2, 3 + 4, '5'::int, int_please()];
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (select
-   (keyword_select)
-   (select_expression
-    (term
-     (array
-      (keyword_array)
-      (literal)
-      (literal)
-      (binary_expression
-       (literal)
-       (literal))
-      (cast
-       (literal)
-       (keyword_int))
-      (invocation
-       (identifier))))))))
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (array
+            (keyword_array)
+            (literal)
+            (literal)
+            (binary_expression
+              (literal)
+              (literal))
+            (cast
+              (literal)
+              (keyword_int))
+            (invocation
+              (identifier))))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -1069,6 +1069,51 @@ ON a.id = b.a_id;
             name: (identifier)))))))
 
 ================================================================================
+Ignore index for join
+================================================================================
+
+SELECT 1
+FROM my_table a
+JOIN my_other_table b IGNORE INDEX FOR JOIN (idx_a)
+ON a.id = b.a_id;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (literal))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (join
+        (keyword_join)
+        (relation
+          (table_reference
+            name: (identifier))
+          table_alias: (identifier))
+        (index_hint
+          (keyword_ignore)
+          (keyword_index)
+          (keyword_for)
+          (keyword_join)
+          index_name: (identifier))
+        (keyword_on)
+        (predicate
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
+
+================================================================================
 Joins with USING
 ================================================================================
 


### PR DESCRIPTION
## What

I added a commit with some small refactors, mostly moving tests for group by to it's own file and adding an extra test case for COUNT in the HAVING clause.

The second commit adds support for `IGNORE INDEX`, there was no keyword for ignore either.