### PR TITLE
Disjunctive fixes & Unary Predicate enhancements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -20,6 +20,7 @@ module.exports = grammar({
       'binary_concat',
       'pattern_matching',
       'clause_connective',
+      'clause_disjunctive',
     ],
   ],
 
@@ -1391,7 +1392,6 @@ module.exports = grammar({
         [seq($.keyword_is, $.keyword_not, $.keyword_distinct, $.keyword_from), 'binary_relation'],
         [$.keyword_is, 'binary_relation'],
         [$.is_not, 'binary_relation'],
-        [$.keyword_or, 'clause_connective'],
         [$.keyword_in, 'binary_in'],
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
@@ -1402,6 +1402,7 @@ module.exports = grammar({
       ),
       ...[
         [$.keyword_and, 'clause_connective'],
+        [$.keyword_or, 'clause_disjunctive'],
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('left', $._predicate_expression),

--- a/grammar.js
+++ b/grammar.js
@@ -1373,7 +1373,7 @@ module.exports = grammar({
       alias($._field_predicate, $.predicate),
     ),
 
-    _field_predicate: $ => field('operand', $.field),
+    _field_predicate: $ => prec(0, field('operand', $.field)),
 
     predicate: $ => choice(
       ...[
@@ -1391,7 +1391,6 @@ module.exports = grammar({
         [seq($.keyword_is, $.keyword_not, $.keyword_distinct, $.keyword_from), 'binary_relation'],
         [$.keyword_is, 'binary_relation'],
         [$.is_not, 'binary_relation'],
-        [$.keyword_and, 'clause_connective'],
         [$.keyword_or, 'clause_connective'],
         [$.keyword_in, 'binary_in'],
       ].map(([operator, precedence]) =>
@@ -1401,23 +1400,39 @@ module.exports = grammar({
           field('right', $._expression)
         ))
       ),
+      ...[
+        [$.keyword_and, 'clause_connective'],
+      ].map(([operator, precedence]) =>
+        prec.left(precedence, seq(
+          field('left', $._predicate_expression),
+          field('operator', operator),
+          field('right', $._predicate_expression)
+        ))
+      ),
     ),
 
-    _expression: $ => choice(
-      $.literal,
-      $.field,
-      $.parameter,
-      $.list,
-      $.case,
-      $.window_function,
+    _predicate_expression: $ => choice(
       $.predicate,
-      $.subquery,
-      $.cast,
-      alias($.implicit_cast, $.cast),
-      $.count,
-      $.invocation,
-      $.binary_expression,
-      $.array,
+      alias($._field_predicate, $.predicate),
+    ),
+
+    _expression: $ => prec(1,
+      choice(
+        $.literal,
+        $.field,
+        $.parameter,
+        $.list,
+        $.case,
+        $.window_function,
+        $.predicate,
+        $.subquery,
+        $.cast,
+        alias($.implicit_cast, $.cast),
+        $.count,
+        $.invocation,
+        $.binary_expression,
+        $.array,
+      )
     ),
 
     binary_expression: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5746,11 +5746,15 @@
       ]
     },
     "_field_predicate": {
-      "type": "FIELD",
-      "name": "operand",
+      "type": "PREC",
+      "value": 0,
       "content": {
-        "type": "SYMBOL",
-        "name": "field"
+        "type": "FIELD",
+        "name": "operand",
+        "content": {
+          "type": "SYMBOL",
+          "name": "field"
+        }
       }
     },
     "predicate": {
@@ -6250,72 +6254,6 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": "clause_connective",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "keyword_and"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": "clause_connective",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "keyword_or"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
           "value": "binary_in",
           "content": {
             "type": "SEQ",
@@ -6346,74 +6284,162 @@
               }
             ]
           }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "clause_connective",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_predicate_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "keyword_and"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_predicate_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "clause_disjunctive",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_predicate_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "keyword_or"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_predicate_expression"
+                }
+              }
+            ]
+          }
         }
       ]
     },
-    "_expression": {
+    "_predicate_expression": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "SYMBOL",
-          "name": "literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "field"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "parameter"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "list"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "case"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "window_function"
-        },
         {
           "type": "SYMBOL",
           "name": "predicate"
         },
         {
-          "type": "SYMBOL",
-          "name": "subquery"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "cast"
-        },
-        {
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "implicit_cast"
+            "name": "_field_predicate"
           },
           "named": true,
-          "value": "cast"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "count"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "invocation"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "binary_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "array"
+          "value": "predicate"
         }
       ]
+    },
+    "_expression": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "literal"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "field"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "parameter"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "list"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "case"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "window_function"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "predicate"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "subquery"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "cast"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "implicit_cast"
+            },
+            "named": true,
+            "value": "cast"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "count"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "invocation"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "binary_expression"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "array"
+          }
+        ]
+      }
     },
     "binary_expression": {
       "type": "CHOICE",
@@ -6893,6 +6919,10 @@
       {
         "type": "STRING",
         "value": "clause_connective"
+      },
+      {
+        "type": "STRING",
+        "value": "clause_disjunctive"
       }
     ]
   ],

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -836,6 +836,60 @@ WHERE m.status = "success"
                 name: (identifier)))))))))
 
 ================================================================================
+Disjunctive Predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE m.status = "success"
+  AND m.name = "foobar"
+  OR m.id = 5
+  AND m.is_not_deleted
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (predicate
+            left: (predicate
+              left: (predicate
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal))
+              operator: (keyword_and)
+              right: (predicate
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal)))
+            operator: (keyword_or)
+            right: (predicate
+              left: (predicate
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal))
+              operator: (keyword_and)
+              right: (predicate
+                operand: (field
+                  table_alias: (identifier)
+                  name: (identifier))))))))))
+
+================================================================================
 IS NOT DISTINCT FROM
 ================================================================================
 

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -771,13 +771,69 @@ WHERE m.is_not_deleted AND m.is_visible;
         (keyword_where)
         (where_expression
           (predicate
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
+            left: (predicate
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))
             operator: (keyword_and)
-            right: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+            right: (predicate
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))))))))
+
+================================================================================
+Mixed Predicate types
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE m.status = "success"
+  AND m.name = "foobar"
+  AND m.id = 5
+  AND m.is_not_deleted
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (predicate
+            left: (predicate
+              left: (predicate
+                left: (predicate
+                  left: (field
+                    table_alias: (identifier)
+                    name: (identifier))
+                  right: (literal))
+                operator: (keyword_and)
+                right: (predicate
+                  left: (field
+                    table_alias: (identifier)
+                    name: (identifier))
+                  right: (literal)))
+              operator: (keyword_and)
+              right: (predicate
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal)))
+            operator: (keyword_and)
+            right: (predicate
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))))))))
 
 ================================================================================
 IS NOT DISTINCT FROM


### PR DESCRIPTION
## What

I fixed the precedence for predicates connected with `OR` e.g. disjunctive predicates.
I also fixed the handling of nested unary predicates e.g.

```sql
is_not_deleted AND is_published
```

```scheme
(predicate
  left: (predicate
    operand: (field name: (identifier)))
  operator: (keyword_and)
  right: (predicate
    operand: (field name: (identifier))))
```

Previously it was

```scheme
(predicate
  left: (field name: (identifier))
  operator: (keyword_and)
  right: (field name: (identifier)))
```

