### PR TITLE
Add unary predicates that work with field predicates

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1381,6 +1381,7 @@ module.exports = grammar({
     _unary_predicate: $ => prec(0, choice(
       ...[
         [$.keyword_not, 'unary_not'],
+        [$.bang, 'unary_not'],
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('operator', operator),
@@ -1491,6 +1492,8 @@ module.exports = grammar({
       $._double_quote_string,
     ),
     _number: _ => /\d+/,
+
+    bang: _ => '!',
 
     identifier: $ => choice(
       $._identifier,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5800,6 +5800,31 @@
                 }
               ]
             }
+          },
+          {
+            "type": "PREC_LEFT",
+            "value": "unary_not",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "operator",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "bang"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "operand",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                }
+              ]
+            }
           }
         ]
       }
@@ -6883,6 +6908,10 @@
     "_number": {
       "type": "PATTERN",
       "value": "\\d+"
+    },
+    "bang": {
+      "type": "STRING",
+      "value": "!"
     },
     "identifier": {
       "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -514,17 +514,21 @@
       ]
     },
     "is_not": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "keyword_is"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "keyword_not"
-        }
-      ]
+      "type": "PREC",
+      "value": "is_not",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "keyword_is"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "keyword_not"
+          }
+        ]
+      }
     },
     "_not_like": {
       "type": "SEQ",
@@ -5742,12 +5746,21 @@
           },
           "named": true,
           "value": "predicate"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_unary_predicate"
+          },
+          "named": true,
+          "value": "predicate"
         }
       ]
     },
     "_field_predicate": {
       "type": "PREC",
-      "value": 0,
+      "value": 1,
       "content": {
         "type": "FIELD",
         "name": "operand",
@@ -5755,6 +5768,40 @@
           "type": "SYMBOL",
           "name": "field"
         }
+      }
+    },
+    "_unary_predicate": {
+      "type": "PREC",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PREC_LEFT",
+            "value": "unary_not",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "operator",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "keyword_not"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "operand",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     "predicate": {
@@ -6368,12 +6415,21 @@
           },
           "named": true,
           "value": "predicate"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_unary_predicate"
+          },
+          "named": true,
+          "value": "predicate"
         }
       ]
     },
     "_expression": {
       "type": "PREC",
-      "value": 1,
+      "value": 2,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -6880,6 +6936,10 @@
   "conflicts": [],
   "precedences": [
     [
+      {
+        "type": "STRING",
+        "value": "is_not"
+      },
       {
         "type": "STRING",
         "value": "unary_not"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3244,6 +3244,10 @@
             "named": false
           },
           {
+            "type": "bang",
+            "named": true
+          },
+          {
             "type": "is_not",
             "named": true
           },
@@ -4256,6 +4260,10 @@
   {
     "type": "`",
     "named": false
+  },
+  {
+    "type": "bang",
+    "named": true
   },
   {
     "type": "keyword_add",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3162,7 +3162,55 @@
         "required": false,
         "types": [
           {
+            "type": "array",
+            "named": true
+          },
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "cast",
+            "named": true
+          },
+          {
+            "type": "count",
+            "named": true
+          },
+          {
             "type": "field",
+            "named": true
+          },
+          {
+            "type": "invocation",
+            "named": true
+          },
+          {
+            "type": "list",
+            "named": true
+          },
+          {
+            "type": "literal",
+            "named": true
+          },
+          {
+            "type": "parameter",
+            "named": true
+          },
+          {
+            "type": "predicate",
+            "named": true
+          },
+          {
+            "type": "subquery",
+            "named": true
+          },
+          {
+            "type": "window_function",
             "named": true
           }
         ]

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -921,6 +921,37 @@ WHERE NOT m.is_deleted;
               name: (identifier))))))))
 
 ================================================================================
+Field Predicate w/ anonymous unary predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE !m.is_deleted;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (predicate
+            operator: (bang)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
+
+================================================================================
 Field Predicate w/ multiple unary predicate
 ================================================================================
 

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -890,6 +890,76 @@ WHERE m.status = "success"
                   name: (identifier))))))))))
 
 ================================================================================
+Field Predicate w/ unary predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE NOT m.is_deleted;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (predicate
+            operator: (keyword_not)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
+
+================================================================================
+Field Predicate w/ multiple unary predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE NOT m.is_deleted
+  AND NOT m.is_invisible;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (predicate
+            left: (predicate
+              operator: (keyword_not)
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))
+            operator: (keyword_and)
+            right: (predicate
+              operator: (keyword_not)
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))))))))
+
+================================================================================
 IS NOT DISTINCT FROM
 ================================================================================
 


### PR DESCRIPTION
## What

As indicated in the tests, this PR fixes field predicates with unary operators e.g. NOT

```sql
SELECT *
FROM my_table m
WHERE NOT m.is_deleted
  AND NOT m.is_invisible;
```

## Considerations

At the moment we consider `NULL` to be a literal value but according to [this reference](https://forcedotcom.github.io/phoenix/index.html#expression)  `IS NULL` & `IS NOT NULL` are special cases of the `condition` term in the grammar (we use `predicate` in place of `condition` in our grammar but they are largely the same).

<img width="461" alt="Screenshot 2022-12-21 at 2 38 18 PM" src="https://user-images.githubusercontent.com/6456191/208989043-c07b1803-9deb-4958-a7e7-3a0aae69dcd9.png">


We have a couple strategies that are possible for the following where node:

```sql
WHERE NOT foo
  AND bar IS NOT NULL
```

1. Switch to the special case form from the grammar

```
(predicate
  left: (predicate
     operator: (keyword_not)
     operand: (field name: (identifier)) @foo
  operator: (keyword_and)
  right: (predicate
    operand: (field name: (identifier)) @bar
    operator: (is_not_null (keyword_is) (keyword_not) (keyword_null))))
```

2. Remove the `is_not` node. This is my preferred next steps.

```
(predicate
  left: (predicate
     operator: (keyword_not)
     operand: (field name: (identifier)) @foo
  operator: (keyword_and)
  right: (predicate
    left: (field name: (identifier)) @bar
    operator: (keyword_is)
    right: (predicate
      operator: (keyword_not) @unary_predicate
      operand: (literal (keyword_null)))))
```

3. Keep the grammar the same as it is now

```
(predicate
  left: (predicate
     operator: (keyword_not)
     operand: (field name: (identifier)) @foo
  operator: (keyword_and)
  right: (predicate
    left: (field name: (identifier)) @bar
    operator: (is_not (keyword_is) (keyword_not))
    right: (literal (keyword_null))))
```