### PR TITLE
Remove predicate and merge into binary_expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,9 @@
 
 [![Build/test](https://github.com/derekstride/tree-sitter-sql/actions/workflows/ci.yml/badge.svg)](https://github.com/derekstride/tree-sitter-sql/actions/workflows/ci.yml)
 
-SQL grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
+A general/permissive SQL grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
 ## Features
-
-- [x] SELECT statements (some features may be incomplete)
-- [x] Function calls
-- [x] Index hints
-- [x] Comments
-- [x] Marginalia
-- [x] UPDATE statements
-- [x] DELETE statements
-- [x] CREATE statements
-- [x] INSERT/REPLACE statements
-- [x] DROP statements
-- [x] ALTER TABLE statements
-- [ ] CREATE INDEX statements
-- [ ] DROP INDEX statements
-- [ ] ALTER INDEX statements
-- [ ] EXPLAIN statements
-- [ ] Function definitions
 
 For a complete list of features see the the [tests](test/corpus)
 
@@ -29,8 +12,8 @@ For a complete list of features see the the [tests](test/corpus)
 
 * [Wikipedia#SQL_syntax](https://en.wikipedia.org/wiki/SQL_syntax) - I consulted wikipedia for naming conventions,
   though I may not have been strict early on in the prototyping.
-* [Phoenix Language Reference](https://forcedotcom.github.io/phoenix/index.html) - Note I'm using this as a reference
-  but implementing the Grammar in terms of the MySQL dialect of SQL.
+* [Phoenix Language Reference](https://forcedotcom.github.io/phoenix/index.html) - A reference diagram.
+* [SQLite's railroad diagram for expr](https://www.sqlite.org/lang_expr.html) - Another reference diagram.
 
 ### Other projects
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -514,17 +514,21 @@
       ]
     },
     "is_not": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "keyword_is"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "keyword_not"
-        }
-      ]
+      "type": "PREC",
+      "value": "binary_is",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "keyword_is"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "keyword_not"
+          }
+        ]
+      }
     },
     "_not_like": {
       "type": "SEQ",
@@ -2235,10 +2239,6 @@
             {
               "type": "SYMBOL",
               "name": "case"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "predicate"
             },
             {
               "type": "SYMBOL",
@@ -4243,7 +4243,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "predicate"
+                      "name": "binary_expression"
                     },
                     {
                       "type": "SYMBOL",
@@ -4270,7 +4270,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "predicate"
+                        "name": "binary_expression"
                       },
                       {
                         "type": "SYMBOL",
@@ -5325,21 +5325,8 @@
                   "name": "keyword_on"
                 },
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "predicate"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "keyword_true"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "keyword_false"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "join_expression"
                 }
               ]
             },
@@ -5364,6 +5351,10 @@
           ]
         }
       ]
+    },
+    "join_expression": {
+      "type": "SYMBOL",
+      "name": "_expression"
     },
     "lateral_join": {
       "type": "SEQ",
@@ -5474,7 +5465,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "predicate"
+              "name": "_expression"
             },
             {
               "type": "SYMBOL",
@@ -5500,6 +5491,10 @@
           "name": "where_expression"
         }
       ]
+    },
+    "where_expression": {
+      "type": "SYMBOL",
+      "name": "_expression"
     },
     "group_by": {
       "type": "SEQ",
@@ -5539,7 +5534,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "predicate"
+          "name": "_expression"
         }
       ]
     },
@@ -5727,39 +5722,310 @@
         }
       ]
     },
-    "where_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "predicate"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_field_predicate"
-          },
-          "named": true,
-          "value": "predicate"
-        }
-      ]
-    },
-    "_field_predicate": {
+    "_expression": {
       "type": "PREC",
-      "value": 0,
+      "value": 1,
       "content": {
-        "type": "FIELD",
-        "name": "operand",
-        "content": {
-          "type": "SYMBOL",
-          "name": "field"
-        }
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "literal"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "field"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "parameter"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "list"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "case"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "window_function"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "subquery"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "cast"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "implicit_cast"
+            },
+            "named": true,
+            "value": "cast"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "count"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "invocation"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "binary_expression"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "unary_expression"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "array"
+          }
+        ]
       }
     },
-    "predicate": {
+    "binary_expression": {
       "type": "CHOICE",
       "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_plus",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "+"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_plus",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "-"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_times",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "*"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_times",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "/"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_times",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "%"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_exp",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "^"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_concat",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "||"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
         {
           "type": "PREC_LEFT",
           "value": "binary_relation",
@@ -6188,7 +6454,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": "binary_relation",
+          "value": "binary_in",
           "content": {
             "type": "SEQ",
             "members": [
@@ -6221,7 +6487,7 @@
         },
         {
           "type": "PREC_LEFT",
-          "value": "binary_relation",
+          "value": "binary_in",
           "content": {
             "type": "SEQ",
             "members": [
@@ -6296,7 +6562,7 @@
                 "name": "left",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_predicate_expression"
+                  "name": "_expression"
                 }
               },
               {
@@ -6312,7 +6578,7 @@
                 "name": "right",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_predicate_expression"
+                  "name": "_expression"
                 }
               }
             ]
@@ -6329,7 +6595,7 @@
                 "name": "left",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_predicate_expression"
+                  "name": "_expression"
                 }
               },
               {
@@ -6345,7 +6611,7 @@
                 "name": "right",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_predicate_expression"
+                  "name": "_expression"
                 }
               }
             ]
@@ -6353,329 +6619,64 @@
         }
       ]
     },
-    "_predicate_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "predicate"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_field_predicate"
-          },
-          "named": true,
-          "value": "predicate"
-        }
-      ]
-    },
-    "_expression": {
+    "unary_expression": {
       "type": "PREC",
-      "value": 1,
+      "value": "unary_not",
       "content": {
         "type": "CHOICE",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "literal"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "field"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "parameter"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "list"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "case"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "window_function"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "predicate"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "subquery"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "cast"
-          },
-          {
-            "type": "ALIAS",
+            "type": "PREC_LEFT",
+            "value": "unary_not",
             "content": {
-              "type": "SYMBOL",
-              "name": "implicit_cast"
-            },
-            "named": true,
-            "value": "cast"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "operator",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "keyword_not"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "operand",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                }
+              ]
+            }
           },
           {
-            "type": "SYMBOL",
-            "name": "count"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "invocation"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "binary_expression"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "array"
+            "type": "PREC_LEFT",
+            "value": "unary_not",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "operator",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "bang"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "operand",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                }
+              ]
+            }
           }
         ]
       }
-    },
-    "binary_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC_LEFT",
-          "value": "binary_plus",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "+"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": "binary_plus",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "-"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": "binary_times",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "*"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": "binary_times",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "/"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": "binary_times",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "%"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": "binary_exp",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "^"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": "binary_concat",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "left",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "STRING",
-                  "value": "||"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                }
-              }
-            ]
-          }
-        }
-      ]
     },
     "subquery": {
       "type": "SEQ",
@@ -6828,6 +6829,10 @@
       "type": "PATTERN",
       "value": "\\d+"
     },
+    "bang": {
+      "type": "STRING",
+      "value": "!"
+    },
     "identifier": {
       "type": "CHOICE",
       "members": [
@@ -6880,6 +6885,10 @@
   "conflicts": [],
   "precedences": [
     [
+      {
+        "type": "STRING",
+        "value": "binary_is"
+      },
       {
         "type": "STRING",
         "value": "unary_not"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -302,11 +302,11 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "subquery",
           "named": true
         },
         {
-          "type": "subquery",
+          "type": "unary_expression",
           "named": true
         },
         {
@@ -475,11 +475,11 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "subquery",
           "named": true
         },
         {
-          "type": "subquery",
+          "type": "unary_expression",
           "named": true
         },
         {
@@ -548,11 +548,11 @@
             "named": true
           },
           {
-            "type": "predicate",
+            "type": "subquery",
             "named": true
           },
           {
-            "type": "subquery",
+            "type": "unary_expression",
             "named": true
           },
           {
@@ -653,11 +653,11 @@
             "named": true
           },
           {
-            "type": "predicate",
+            "type": "subquery",
             "named": true
           },
           {
-            "type": "subquery",
+            "type": "unary_expression",
             "named": true
           },
           {
@@ -667,9 +667,13 @@
         ]
       },
       "operator": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "!=",
+            "named": false
+          },
           {
             "type": "%",
             "named": false
@@ -691,8 +695,72 @@
             "named": false
           },
           {
+            "type": "<",
+            "named": false
+          },
+          {
+            "type": "<=",
+            "named": false
+          },
+          {
+            "type": "=",
+            "named": false
+          },
+          {
+            "type": ">",
+            "named": false
+          },
+          {
+            "type": ">=",
+            "named": false
+          },
+          {
             "type": "^",
             "named": false
+          },
+          {
+            "type": "is_not",
+            "named": true
+          },
+          {
+            "type": "keyword_and",
+            "named": true
+          },
+          {
+            "type": "keyword_distinct",
+            "named": true
+          },
+          {
+            "type": "keyword_from",
+            "named": true
+          },
+          {
+            "type": "keyword_in",
+            "named": true
+          },
+          {
+            "type": "keyword_is",
+            "named": true
+          },
+          {
+            "type": "keyword_like",
+            "named": true
+          },
+          {
+            "type": "keyword_not",
+            "named": true
+          },
+          {
+            "type": "keyword_or",
+            "named": true
+          },
+          {
+            "type": "keyword_similar",
+            "named": true
+          },
+          {
+            "type": "keyword_to",
+            "named": true
           },
           {
             "type": "||",
@@ -745,11 +813,11 @@
             "named": true
           },
           {
-            "type": "predicate",
+            "type": "subquery",
             "named": true
           },
           {
-            "type": "subquery",
+            "type": "unary_expression",
             "named": true
           },
           {
@@ -833,11 +901,11 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "subquery",
           "named": true
         },
         {
-          "type": "subquery",
+          "type": "unary_expression",
           "named": true
         },
         {
@@ -906,11 +974,11 @@
             "named": true
           },
           {
-            "type": "predicate",
+            "type": "subquery",
             "named": true
           },
           {
-            "type": "subquery",
+            "type": "unary_expression",
             "named": true
           },
           {
@@ -1105,11 +1173,11 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "subquery",
           "named": true
         },
         {
-          "type": "subquery",
+          "type": "unary_expression",
           "named": true
         },
         {
@@ -1572,11 +1640,11 @@
             "named": true
           },
           {
-            "type": "predicate",
+            "type": "subquery",
             "named": true
           },
           {
-            "type": "subquery",
+            "type": "unary_expression",
             "named": true
           },
           {
@@ -2152,10 +2220,6 @@
           "named": true
         },
         {
-          "type": "predicate",
-          "named": true
-        },
-        {
           "type": "subquery",
           "named": true
         }
@@ -2327,7 +2391,35 @@
       "required": true,
       "types": [
         {
+          "type": "array",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
+          "type": "count",
+          "named": true
+        },
+        {
           "type": "expression_list",
+          "named": true
+        },
+        {
+          "type": "field",
+          "named": true
+        },
+        {
+          "type": "invocation",
           "named": true
         },
         {
@@ -2343,7 +2435,27 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "literal",
+          "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "subquery",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "window_function",
           "named": true
         }
       ]
@@ -2537,11 +2649,11 @@
             "named": true
           },
           {
-            "type": "predicate",
+            "type": "subquery",
             "named": true
           },
           {
-            "type": "subquery",
+            "type": "unary_expression",
             "named": true
           },
           {
@@ -2588,11 +2700,11 @@
           "named": true
         },
         {
-          "type": "keyword_cross",
+          "type": "join_expression",
           "named": true
         },
         {
-          "type": "keyword_false",
+          "type": "keyword_cross",
           "named": true
         },
         {
@@ -2620,19 +2732,74 @@
           "named": true
         },
         {
-          "type": "keyword_true",
-          "named": true
-        },
-        {
           "type": "keyword_using",
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "relation",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "join_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "array",
           "named": true
         },
         {
-          "type": "relation",
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
+          "type": "count",
+          "named": true
+        },
+        {
+          "type": "field",
+          "named": true
+        },
+        {
+          "type": "invocation",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "literal",
+          "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "subquery",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "window_function",
           "named": true
         }
       ]
@@ -2723,6 +2890,30 @@
       "required": true,
       "types": [
         {
+          "type": "array",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
+          "type": "count",
+          "named": true
+        },
+        {
+          "type": "field",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -2767,11 +2958,27 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "literal",
+          "named": true
+        },
+        {
+          "type": "parameter",
           "named": true
         },
         {
           "type": "subquery",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "window_function",
           "named": true
         }
       ]
@@ -2849,11 +3056,11 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "subquery",
           "named": true
         },
         {
-          "type": "subquery",
+          "type": "unary_expression",
           "named": true
         },
         {
@@ -3053,11 +3260,11 @@
           "named": true
         },
         {
-          "type": "predicate",
+          "type": "subquery",
           "named": true
         },
         {
-          "type": "subquery",
+          "type": "unary_expression",
           "named": true
         },
         {
@@ -3093,212 +3300,6 @@
           "named": true
         }
       ]
-    }
-  },
-  {
-    "type": "predicate",
-    "named": true,
-    "fields": {
-      "left": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "array",
-            "named": true
-          },
-          {
-            "type": "binary_expression",
-            "named": true
-          },
-          {
-            "type": "case",
-            "named": true
-          },
-          {
-            "type": "cast",
-            "named": true
-          },
-          {
-            "type": "count",
-            "named": true
-          },
-          {
-            "type": "field",
-            "named": true
-          },
-          {
-            "type": "invocation",
-            "named": true
-          },
-          {
-            "type": "list",
-            "named": true
-          },
-          {
-            "type": "literal",
-            "named": true
-          },
-          {
-            "type": "parameter",
-            "named": true
-          },
-          {
-            "type": "predicate",
-            "named": true
-          },
-          {
-            "type": "subquery",
-            "named": true
-          },
-          {
-            "type": "window_function",
-            "named": true
-          }
-        ]
-      },
-      "operand": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "field",
-            "named": true
-          }
-        ]
-      },
-      "operator": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "!=",
-            "named": false
-          },
-          {
-            "type": "<",
-            "named": false
-          },
-          {
-            "type": "<=",
-            "named": false
-          },
-          {
-            "type": "=",
-            "named": false
-          },
-          {
-            "type": ">",
-            "named": false
-          },
-          {
-            "type": ">=",
-            "named": false
-          },
-          {
-            "type": "is_not",
-            "named": true
-          },
-          {
-            "type": "keyword_and",
-            "named": true
-          },
-          {
-            "type": "keyword_distinct",
-            "named": true
-          },
-          {
-            "type": "keyword_from",
-            "named": true
-          },
-          {
-            "type": "keyword_in",
-            "named": true
-          },
-          {
-            "type": "keyword_is",
-            "named": true
-          },
-          {
-            "type": "keyword_like",
-            "named": true
-          },
-          {
-            "type": "keyword_not",
-            "named": true
-          },
-          {
-            "type": "keyword_or",
-            "named": true
-          },
-          {
-            "type": "keyword_similar",
-            "named": true
-          },
-          {
-            "type": "keyword_to",
-            "named": true
-          }
-        ]
-      },
-      "right": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "array",
-            "named": true
-          },
-          {
-            "type": "binary_expression",
-            "named": true
-          },
-          {
-            "type": "case",
-            "named": true
-          },
-          {
-            "type": "cast",
-            "named": true
-          },
-          {
-            "type": "count",
-            "named": true
-          },
-          {
-            "type": "field",
-            "named": true
-          },
-          {
-            "type": "invocation",
-            "named": true
-          },
-          {
-            "type": "list",
-            "named": true
-          },
-          {
-            "type": "literal",
-            "named": true
-          },
-          {
-            "type": "parameter",
-            "named": true
-          },
-          {
-            "type": "predicate",
-            "named": true
-          },
-          {
-            "type": "subquery",
-            "named": true
-          },
-          {
-            "type": "window_function",
-            "named": true
-          }
-        ]
-      }
     }
   },
   {
@@ -3783,11 +3784,11 @@
             "named": true
           },
           {
-            "type": "predicate",
+            "type": "subquery",
             "named": true
           },
           {
-            "type": "subquery",
+            "type": "unary_expression",
             "named": true
           },
           {
@@ -3837,6 +3838,84 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "unary_expression",
+    "named": true,
+    "fields": {
+      "operand": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array",
+            "named": true
+          },
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "cast",
+            "named": true
+          },
+          {
+            "type": "count",
+            "named": true
+          },
+          {
+            "type": "field",
+            "named": true
+          },
+          {
+            "type": "invocation",
+            "named": true
+          },
+          {
+            "type": "list",
+            "named": true
+          },
+          {
+            "type": "literal",
+            "named": true
+          },
+          {
+            "type": "parameter",
+            "named": true
+          },
+          {
+            "type": "subquery",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          },
+          {
+            "type": "window_function",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "bang",
+            "named": true
+          },
+          {
+            "type": "keyword_not",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3955,7 +4034,55 @@
       "required": true,
       "types": [
         {
-          "type": "predicate",
+          "type": "array",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
+          "type": "count",
+          "named": true
+        },
+        {
+          "type": "field",
+          "named": true
+        },
+        {
+          "type": "invocation",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "literal",
+          "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "subquery",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "window_function",
           "named": true
         }
       ]
@@ -4208,6 +4335,10 @@
   {
     "type": "`",
     "named": false
+  },
+  {
+    "type": "bang",
+    "named": true
   },
   {
     "type": "keyword_add",

--- a/test/corpus/delete.txt
+++ b/test/corpus/delete.txt
@@ -104,6 +104,6 @@ WHERE id = 9;
    (where
     (keyword_where)
     (where_expression
-     (predicate
+     (binary_expression
       left: (field name: (identifier))
       right: (literal)))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,0 +1,549 @@
+================================================================================
+Single Field Predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE m.is_not_deleted;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (field
+            table_alias: (identifier)
+            name: (identifier)))))))
+
+================================================================================
+Multiple Field Predicates
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE m.is_not_deleted AND m.is_visible;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            operator: (keyword_and)
+            right: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
+
+================================================================================
+Single Unary Predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE NOT m.is_not_deleted;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (unary_expression
+            operator: (keyword_not)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
+
+================================================================================
+Multiple Unary Predicates
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE NOT m.is_not_deleted
+  AND NOT m.is_visible;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (unary_expression
+              operator: (keyword_not)
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))
+            operator: (keyword_and)
+            right: (unary_expression
+              operator: (keyword_not)
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))))))))
+
+================================================================================
+Mixed Predicate types
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE m.status = "success"
+  AND m.name = "foobar"
+  AND m.id = 5
+  AND m.is_not_deleted
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (binary_expression
+              left: (binary_expression
+                left: (binary_expression
+                  left: (field
+                    table_alias: (identifier)
+                    name: (identifier))
+                  right: (literal))
+                operator: (keyword_and)
+                right: (binary_expression
+                  left: (field
+                    table_alias: (identifier)
+                    name: (identifier))
+                  right: (literal)))
+              operator: (keyword_and)
+              right: (binary_expression
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal)))
+            operator: (keyword_and)
+            right: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
+
+================================================================================
+Disjunctive Predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE m.status = "success"
+  AND m.name = "foobar"
+  OR m.id = 5
+  AND m.is_not_deleted
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (binary_expression
+              left: (binary_expression
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal))
+              operator: (keyword_and)
+              right: (binary_expression
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal)))
+            operator: (keyword_or)
+            right: (binary_expression
+              left: (binary_expression
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal))
+              operator: (keyword_and)
+              right: (field
+                table_alias: (identifier)
+                name: (identifier)))))))))
+
+================================================================================
+Field Predicate w/ unary predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE NOT m.is_deleted;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (unary_expression
+            operator: (keyword_not)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
+
+================================================================================
+Field Predicate w/ anonymous unary predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE !m.is_deleted;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (unary_expression
+            operator: (bang)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
+
+================================================================================
+Field Predicate w/ multiple unary predicate
+================================================================================
+
+SELECT *
+FROM my_table m
+WHERE NOT m.is_deleted
+  AND NOT m.is_invisible;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (unary_expression
+              operator: (keyword_not)
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))
+            operator: (keyword_and)
+            right: (unary_expression
+              operator: (keyword_not)
+              operand: (field
+                table_alias: (identifier)
+                name: (identifier)))))))))
+
+================================================================================
+IS DISTINCT FROM
+================================================================================
+
+SELECT *
+FROM my_table
+WHERE col IS DISTINCT FROM NULL;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier)))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            (field
+              (identifier))
+            (keyword_is)
+            (keyword_distinct)
+            (keyword_from)
+            (literal
+              (keyword_null))))))))
+
+================================================================================
+IS NOT DISTINCT FROM
+================================================================================
+
+SELECT *
+FROM my_table
+WHERE col IS NOT DISTINCT FROM NULL;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier)))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            (field
+              (identifier))
+            (keyword_is)
+            (keyword_not)
+            (keyword_distinct)
+            (keyword_from)
+            (literal
+              (keyword_null))))))))
+
+================================================================================
+Predicates with keywords
+================================================================================
+
+SELECT *
+FROM my_table
+WHERE id IS NOT NULL
+  AND name IS NULL;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (binary_expression
+              left: (field
+                name: (identifier))
+              operator: (is_not
+                (keyword_is)
+                (keyword_not))
+              right: (literal
+                (keyword_null)))
+            operator: (keyword_and)
+            right: (binary_expression
+              left: (field
+                name: (identifier))
+              operator: (keyword_is)
+              right: (literal
+                (keyword_null)))))))))
+
+================================================================================
+Complex Predicates
+================================================================================
+
+SELECT id
+FROM my_table m
+WHERE m.id > 4 AND id < 3;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+            name: (identifier)))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (literal))
+            operator: (keyword_and)
+            right: (binary_expression
+              left: (field
+                name: (identifier))
+              right: (literal))))))))
+
+================================================================================
+Where with pattern matching
+================================================================================
+
+SELECT
+    *
+FROM
+    a
+WHERE
+        a LIKE '%a'
+    AND a NOT LIKE '%a'
+    AND a SIMILAR TO '%a'
+    AND a NOT SIMILAR TO '%a';
+
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (where
+        (keyword_where)
+        (where_expression
+          (binary_expression
+            left: (binary_expression
+              left: (binary_expression
+                left: (binary_expression
+                  left: (field
+                    name: (identifier))
+                  operator: (keyword_like)
+                  right: (literal))
+                operator: (keyword_and)
+                right: (binary_expression
+                  left: (field
+                    name: (identifier))
+                  operator: (keyword_not)
+                  operator: (keyword_like)
+                  right: (literal)))
+              operator: (keyword_and)
+              right: (binary_expression
+                left: (field
+                  name: (identifier))
+                operator: (keyword_similar)
+                operator: (keyword_to)
+                right: (literal)))
+            operator: (keyword_and)
+            right: (binary_expression
+              left: (field
+                name: (identifier))
+              operator: (keyword_not)
+              operator: (keyword_similar)
+              operator: (keyword_to)
+              right: (literal))))))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -69,7 +69,7 @@ FROM my_table AS t;
               parameter: (field
                 name: (identifier))
               parameter: (literal))
-            parameter: (predicate
+            parameter: (binary_expression
               left: (binary_expression
                 left: (field
                   name: (identifier))

--- a/test/corpus/group_by.txt
+++ b/test/corpus/group_by.txt
@@ -34,7 +34,7 @@ HAVING other_id > 10;
           (field
             name: (identifier)))
         (keyword_having)
-        (predicate
+        (binary_expression
           left: (field
             name: (identifier))
           right: (literal))))))
@@ -73,7 +73,7 @@ HAVING other_id > 10;
         (expression_list
           (literal))
         (keyword_having)
-        (predicate
+        (binary_expression
           left: (field
             name: (identifier))
           right: (literal))))))
@@ -117,7 +117,7 @@ HAVING other_id > 10;
           (field
             name: (identifier)))
         (keyword_having)
-        (predicate
+        (binary_expression
           left: (field
             name: (identifier))
           right: (literal))))))
@@ -158,7 +158,7 @@ HAVING COUNT(*) = 2;
           (field
             (identifier)))
         (keyword_having)
-        (predicate
+        (binary_expression
           (count
             (identifier)
             (all_fields))

--- a/test/corpus/index.txt
+++ b/test/corpus/index.txt
@@ -54,7 +54,7 @@ WHERE tab.col > 10;
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             (field
               (identifier)
               (identifier))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -218,48 +218,6 @@ FROM my_table m;
         table_alias: (identifier)))))
 
 ================================================================================
-Predicates with keywords
-================================================================================
-
-SELECT *
-FROM my_table
-WHERE id IS NOT NULL
-  AND name IS NULL;
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier)))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            left: (predicate
-              left: (field
-                name: (identifier))
-              operator: (is_not
-                (keyword_is)
-                (keyword_not))
-              right: (literal
-                (keyword_null)))
-            operator: (keyword_and)
-            right: (predicate
-              left: (field
-                name: (identifier))
-              operator: (keyword_is)
-              right: (literal
-                (keyword_null)))))))))
-
-================================================================================
 Simple select with aliased table and column name using double quotes
 ================================================================================
 
@@ -312,7 +270,7 @@ WHERE id = 4;
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             left: (field
               name: (identifier))
             right: (literal)))))))
@@ -343,7 +301,7 @@ WHERE id = "abc";
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             left: (field
               name: (identifier))
             right: (literal)))))))
@@ -374,7 +332,7 @@ WHERE id IN(1,2);
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             left: (field
               name: (identifier))
             operator: (keyword_in)
@@ -434,7 +392,7 @@ FROM my_table m;
         (term
           value: (invocation
             name: (identifier)
-            parameter: (predicate
+            parameter: (binary_expression
               left: (field
                 table_alias: (identifier)
                 name: (identifier))
@@ -561,7 +519,7 @@ ORDER BY id DESC;
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             left: (field
               name: (identifier))
             right: (literal))))
@@ -681,247 +639,6 @@ FROM
         (table_reference
           schema: (identifier)
           name: (identifier))))))
-
-================================================================================
-IS DISTINCT FROM
-================================================================================
-
-SELECT *
-FROM my_table
-WHERE col IS DISTINCT FROM NULL;
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          (identifier)))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            (field
-              (identifier))
-            (keyword_is)
-            (keyword_distinct)
-            (keyword_from)
-            (literal
-              (keyword_null))))))))
-
-================================================================================
-Single Unary Predicate
-================================================================================
-
-SELECT *
-FROM my_table m
-WHERE m.is_not_deleted;
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier))
-        table_alias: (identifier))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            operand: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
-
-================================================================================
-Multiple Unary Predicates
-================================================================================
-
-SELECT *
-FROM my_table m
-WHERE m.is_not_deleted AND m.is_visible;
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier))
-        table_alias: (identifier))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            left: (predicate
-              operand: (field
-                table_alias: (identifier)
-                name: (identifier)))
-            operator: (keyword_and)
-            right: (predicate
-              operand: (field
-                table_alias: (identifier)
-                name: (identifier)))))))))
-
-================================================================================
-Mixed Predicate types
-================================================================================
-
-SELECT *
-FROM my_table m
-WHERE m.status = "success"
-  AND m.name = "foobar"
-  AND m.id = 5
-  AND m.is_not_deleted
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier))
-        table_alias: (identifier))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            left: (predicate
-              left: (predicate
-                left: (predicate
-                  left: (field
-                    table_alias: (identifier)
-                    name: (identifier))
-                  right: (literal))
-                operator: (keyword_and)
-                right: (predicate
-                  left: (field
-                    table_alias: (identifier)
-                    name: (identifier))
-                  right: (literal)))
-              operator: (keyword_and)
-              right: (predicate
-                left: (field
-                  table_alias: (identifier)
-                  name: (identifier))
-                right: (literal)))
-            operator: (keyword_and)
-            right: (predicate
-              operand: (field
-                table_alias: (identifier)
-                name: (identifier)))))))))
-
-================================================================================
-Disjunctive Predicate
-================================================================================
-
-SELECT *
-FROM my_table m
-WHERE m.status = "success"
-  AND m.name = "foobar"
-  OR m.id = 5
-  AND m.is_not_deleted
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier))
-        table_alias: (identifier))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            left: (predicate
-              left: (predicate
-                left: (field
-                  table_alias: (identifier)
-                  name: (identifier))
-                right: (literal))
-              operator: (keyword_and)
-              right: (predicate
-                left: (field
-                  table_alias: (identifier)
-                  name: (identifier))
-                right: (literal)))
-            operator: (keyword_or)
-            right: (predicate
-              left: (predicate
-                left: (field
-                  table_alias: (identifier)
-                  name: (identifier))
-                right: (literal))
-              operator: (keyword_and)
-              right: (predicate
-                operand: (field
-                  table_alias: (identifier)
-                  name: (identifier))))))))))
-
-================================================================================
-IS NOT DISTINCT FROM
-================================================================================
-
-SELECT *
-FROM my_table
-WHERE col IS NOT DISTINCT FROM NULL;
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          (identifier)))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            (field
-              (identifier))
-            (keyword_is)
-            (keyword_not)
-            (keyword_distinct)
-            (keyword_from)
-            (literal
-              (keyword_null))))))))
 
 ================================================================================
 Distinct
@@ -1082,17 +799,18 @@ WHERE b.c_id = 4;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             left: (field
               table_alias: (identifier)
               name: (identifier))
@@ -1125,7 +843,9 @@ JOIN my_other_table ON TRUE;
           (table_reference
             name: (identifier)))
         (keyword_on)
-        (keyword_true)))))
+        (join_expression
+          (literal
+            (keyword_true)))))))
 
 ================================================================================
 Joins with hint
@@ -1170,13 +890,14 @@ ON a.id = b.a_id;
           (keyword_join)
           index_name: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier)))))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
 
 ================================================================================
 Ignore index for join
@@ -1215,13 +936,14 @@ ON a.id = b.a_id;
           (keyword_join)
           index_name: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier)))))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
 
 ================================================================================
 Joins with USING
@@ -1305,7 +1027,9 @@ JOIN (VALUES (1, 2), (3, 4)) AS v (col1, col2) ON TRUE;
             (column
               name: (identifier))))
         (keyword_on)
-        (keyword_true)))))
+        (join_expression
+          (literal
+            (keyword_true)))))))
 
 ================================================================================
 Specific Joins
@@ -1349,13 +1073,14 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (join
         (keyword_left)
         (keyword_outer)
@@ -1365,13 +1090,14 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (join
         (keyword_right)
         (keyword_join)
@@ -1380,13 +1106,14 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (join
         (keyword_right)
         (keyword_outer)
@@ -1396,13 +1123,14 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (join
         (keyword_inner)
         (keyword_join)
@@ -1411,13 +1139,14 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier)))))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
 
 ================================================================================
 Lateral join
@@ -1457,7 +1186,8 @@ JOIN LATERAL unnest(a.arr) AS arr ON TRUE;
         (keyword_as)
         alias: (identifier)
         (keyword_on)
-        (keyword_true)))))
+        (literal
+          (keyword_true))))))
 
 ================================================================================
 Lateral join subquery
@@ -1499,7 +1229,8 @@ CROSS JOIN LATERAL (SELECT 1) AS b ON TRUE;
         (keyword_as)
         alias: (identifier)
         (keyword_on)
-        (keyword_true)))))
+        (literal
+          (keyword_true))))))
 
 ================================================================================
 Multiple joins
@@ -1544,13 +1275,14 @@ ON a.id = c.a_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (join
         (keyword_join)
         (relation
@@ -1558,52 +1290,14 @@ ON a.id = c.a_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier)))))))
-
-================================================================================
-Complex Predicates
-================================================================================
-
-SELECT id
-FROM my_table m
-WHERE m.id > 4 AND id < 3;
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          value: (field
-            name: (identifier)))))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier))
-        table_alias: (identifier))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            left: (predicate
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (literal))
-            operator: (keyword_and)
-            right: (predicate
-              left: (field
-                name: (identifier))
-              right: (literal))))))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
 
 ================================================================================
 Complex Predicates with order by
@@ -1636,14 +1330,14 @@ ORDER BY m.title, id ASC;
       (where
         (keyword_where)
         (where_expression
-          (predicate
-            left: (predicate
+          (binary_expression
+            left: (binary_expression
               left: (field
                 table_alias: (identifier)
                 name: (identifier))
               right: (literal))
             operator: (keyword_and)
-            right: (predicate
+            right: (binary_expression
               left: (field
                 name: (identifier))
               right: (literal)))))
@@ -1688,7 +1382,7 @@ ORDER BY id DESC NULLS LAST, val USING < NULLS FIRST;
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             left: (field
               name: (identifier))
             right: (literal))))
@@ -1889,7 +1583,7 @@ FROM my_table;
           (case
             (keyword_case)
             (keyword_when)
-            (predicate
+            (binary_expression
               (field
                 (identifier))
               (literal))
@@ -1935,14 +1629,14 @@ FROM my_table;
           (case
             (keyword_case)
             (keyword_when)
-            (predicate
+            (binary_expression
               (field
                 (identifier))
               (literal))
             (keyword_then)
             (literal)
             (keyword_when)
-            (predicate
+            (binary_expression
               (field
                 (identifier))
               (literal))
@@ -2052,22 +1746,23 @@ ORDER BY my_table.title, my_table.id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (predicate
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))
-          operator: (keyword_and)
-          right: (predicate
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (join_expression
+          (binary_expression
+            left: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (field
+                table_alias: (identifier)
+                name: (identifier)))
+            operator: (keyword_and)
+            right: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (field
+                table_alias: (identifier)
+                name: (identifier))))))
       (join
         (keyword_join)
         (relation
@@ -2080,35 +1775,36 @@ ORDER BY my_table.title, my_table.id;
           (keyword_join)
           index_name: (identifier))
         (keyword_on)
-        (predicate
-          left: (predicate
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))
-          operator: (keyword_and)
-          right: (predicate
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (join_expression
+          (binary_expression
+            left: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (field
+                table_alias: (identifier)
+                name: (identifier)))
+            operator: (keyword_and)
+            right: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (field
+                table_alias: (identifier)
+                name: (identifier))))))
       (where
         (keyword_where)
         (where_expression
-          (predicate
-            left: (predicate
-              left: (predicate
-                left: (predicate
+          (binary_expression
+            left: (binary_expression
+              left: (binary_expression
+                left: (binary_expression
                   left: (field
                     table_alias: (identifier)
                     name: (identifier))
                   right: (literal))
                 operator: (keyword_and)
-                right: (predicate
+                right: (binary_expression
                   left: (field
                     table_alias: (identifier)
                     name: (identifier))
@@ -2116,13 +1812,13 @@ ORDER BY my_table.title, my_table.id;
                   right: (list
                     (literal))))
               operator: (keyword_and)
-              right: (predicate
+              right: (binary_expression
                 left: (field
                   table_alias: (identifier)
                   name: (identifier))
                 right: (literal)))
             operator: (keyword_and)
-            right: (predicate
+            right: (binary_expression
               left: (field
                 table_alias: (identifier)
                 name: (identifier))
@@ -2204,7 +1900,7 @@ WHERE id = ?;
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             (field
               (identifier))
             (parameter)))))))
@@ -2233,7 +1929,7 @@ WHERE id = $12;
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             (field
               (identifier))
             (parameter)))))))
@@ -2307,68 +2003,6 @@ FROM
             (identifier))
           (column
             (identifier)))))))
-
-================================================================================
-Where with pattern matching
-================================================================================
-
-SELECT
-    *
-FROM
-    a
-WHERE
-        a LIKE '%a'
-    AND a NOT LIKE '%a'
-    AND a SIMILAR TO '%a'
-    AND a NOT SIMILAR TO '%a';
-
-
---------------------------------------------------------------------------------
-
-(program
-  (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (all_fields)))
-    (from
-      (keyword_from)
-      (relation
-        (table_reference
-          name: (identifier)))
-      (where
-        (keyword_where)
-        (where_expression
-          (predicate
-            left: (predicate
-              left: (predicate
-                left: (predicate
-                  left: (field
-                    name: (identifier))
-                  operator: (keyword_like)
-                  right: (literal))
-                operator: (keyword_and)
-                right: (predicate
-                  left: (field
-                    name: (identifier))
-                  operator: (keyword_not)
-                  operator: (keyword_like)
-                  right: (literal)))
-              operator: (keyword_and)
-              right: (predicate
-                left: (field
-                  name: (identifier))
-                operator: (keyword_similar)
-                operator: (keyword_to)
-                right: (literal)))
-            operator: (keyword_and)
-            right: (predicate
-              left: (field
-                name: (identifier))
-              operator: (keyword_not)
-              operator: (keyword_similar)
-              operator: (keyword_to)
-              right: (literal))))))))
 
 ================================================================================
 CASE WHEN with bool column
@@ -2504,17 +2138,18 @@ WHERE
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (predicate
-          left: (field
-            table_alias: (identifier)
-            name: (identifier))
-          right: (field
-            table_alias: (identifier)
-            name: (identifier))))
+        (join_expression
+          (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             left: (field
               table_alias: (identifier)
               name: (identifier))

--- a/test/corpus/subquery.txt
+++ b/test/corpus/subquery.txt
@@ -27,7 +27,7 @@ WHERE id < (
       (where
         (keyword_where)
         (where_expression
-          (predicate
+          (binary_expression
             (field
               (identifier))
             (subquery

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -95,7 +95,7 @@ WHERE items.id=month.item_id;
    (where
     (keyword_where)
     (where_expression
-     (predicate
+     (binary_expression
       left: (field table_alias: (identifier) name: (identifier))
       right: (field table_alias: (identifier) name: (identifier))))))))
 

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -567,7 +567,7 @@ FROM
                   (case
                     (keyword_case)
                     (keyword_when)
-                    (predicate
+                    (binary_expression
                       (field
                         (identifier))
                       (literal))
@@ -624,7 +624,7 @@ FROM
                     (case
                       (keyword_case)
                       (keyword_when)
-                      (predicate
+                      (binary_expression
                         (field
                           (identifier))
                         (parameter))


### PR DESCRIPTION
## What

Alternative to #62

The goal of this grammar is to be permissive and be able to parse and make sense of many different SQL dialects. Given this goal we have don't have a clear canonical reference implementation to base our grammar on. There are many conflicting implementations and in the past I haven't compared them in-depth. Without a clear reference and conflicting implementations it leaves us free to choose the best structure for our needs.

> redundancy between our predicate and binary_expression. Really a predicate is a binary (or unary!) expression that resolves to a boolean value.

> If we add not unary predicates but unary expressions we could move all the relation & pattern-matching stuff out of `predicate` into `_expression`

Based on https://github.com/DerekStride/tree-sitter-sql/pull/62#issuecomment-1364591529 this PR implements these ideas. I've removed the `predicate` node from the grammar entirely instead relying on the `_expression` nodes. This is a breaking change but one I think we should consider.

## Context

When it comes to tree-sitter grammars the pattern of having binary & unary expressions as a choice rule under a anonymous _expression node seems to be the common behaviour. e.g.

```rust
/// Rust
-1 + 2;
// (binary_expression
//   left: (unary_expression (integer_literal))
//   right: (integer_literal))
```

```ruby
## Ruby
-1 + 2
# (binary
#   left: (unary operand: (integer))
#   right: (integer))
```

However, unlike Rust [^1] & Ruby [^2] which are imperative languages, SQL is a domain specific declarative language. The notion of a `predicate` node is present in many implementations[^3].

Although, some implementations, e.g. sqlite [^4] make liberal use expressions.

```sqlite3
$ sqlite3
SQLite version 3.39.4 2022-09-07 20:51:41
sqlite> SELECT 1 IS NOT NULL WHERE -8 + 8;
sqlite> SELECT 1 IS NOT NULL WHERE -8 + 7;
1
sqlite> SELECT 1 IS NULL WHERE -8 + 7;
0
```

> In the above example `-8 + 8` gets evaluated to `0` (false) and `-8 + 7` gets evaluated to `-1` (true, any non-zero number is truthy). Additionally, `1 IS NOT NULL` gets evaluated to `1` (true) and `1 IS NULL` to `0` (false).

Given all of the above I think we can justify representing the `predicate` nodes as regular `binary_expression` nodes in our grammar. It's permissive enough to support sqlite and it doesn't seem like the right place to inject the concept of a predicate into the grammar. The tools built on top of the grammar can encode the concept of a predicate if needed.

## Implementations in the Wild

See also https://github.com/DerekStride/tree-sitter-sql/pull/62#issuecomment-1364591529.

[^1]: [tree-sitter-rust grammar](https://github.com/tree-sitter/tree-sitter-rust/blob/f7fb205c424b0962de59b26b931fe484e1262b35/grammar.js#L964-L982)
[^2]: [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby/blob/7a1921bcfd90e3a04c1ad011059087aaf0168dd4/grammar.js#L896-L917)
[^3]: [ANTLR grammar based on MySQL reference](https://github.com/antlr/grammars-v4/blob/38857b99fbb6effa129e2d49182d3814013f8e46/sql/mysql/Positive-Technologies/MySqlParser.g4#L2571-L2590)
[^4]: [SQLite's railroad diagram for expr](https://www.sqlite.org/syntax/expr.html)

