### PR TITLE
more expression and other cleanup

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -762,10 +762,6 @@ module.exports = grammar({
     insert: $ => seq(
       choice($.keyword_insert, $.keyword_replace),
       $.keyword_into,
-      $.insert_expression,
-    ),
-
-    insert_expression: $ => seq(
       $.table_reference,
       optional(alias($._column_list_without_order, $.column_list)),
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -475,26 +475,12 @@ module.exports = grammar({
     ),
 
     expression_list :$ => seq(
-        $._expression_list,
+        $._expression,
         repeat(
             seq(
                 ',',
-                $._expression_list,
+                $._expression,
             )
-        )
-    ),
-
-    _expression_list: $ => seq(
-        choice(
-          $.literal,
-          $.field,
-          $.parameter,
-          $.case,
-          $.subquery,
-          $.cast,
-          alias($.implicit_cast, $.cast),
-          $.invocation,
-          $.binary_expression,
         )
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1134,10 +1134,7 @@ module.exports = grammar({
       optional(
         $.keyword_only,
       ),
-      choice(
-        $.relation_list,
-        $.relation,
-      ),
+      comma_list($.relation, true),
       optional($.index_hint),
       repeat(
         choice(
@@ -1149,16 +1146,6 @@ module.exports = grammar({
       optional($.group_by),
       optional($.order_by),
       optional($.limit),
-    ),
-
-    relation_list: $ => seq(
-      $.relation,
-      repeat1(
-        seq(
-          ',',
-          $.relation,
-        ),
-      ),
     ),
 
     relation: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -1264,15 +1264,7 @@ module.exports = grammar({
     order_by: $ => seq(
       $.keyword_order,
       $.keyword_by,
-      seq(
-        $.order_target,
-        repeat(
-          seq(
-            ',',
-            $.order_target,
-          ),
-        ),
-      ),
+      comma_list($.order_target, true),
     ),
 
     order_target: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -809,7 +809,7 @@ module.exports = grammar({
       ),
       $.table_reference,
       $.keyword_set,
-      $.assignment_list,
+      comma_list($.assignment, true),
       optional($.where),
       optional($.order_by),
       optional($.limit),
@@ -818,7 +818,7 @@ module.exports = grammar({
     _multi_table_update: $ => seq(
       $._table_references,
       $.keyword_set,
-      $.assignment_list,
+      comma_list($.assignment, true),
       optional($.where),
     ),
 
@@ -826,13 +826,6 @@ module.exports = grammar({
       $.table_reference,
       repeat1(
         seq(',', $.table_reference),
-      ),
-    ),
-
-    assignment_list: $ => seq(
-      $.assignment,
-      repeat(
-        seq(',', $.assignment),
       ),
     ),
 
@@ -1467,7 +1460,16 @@ function parametric_type($, type, params = ['size']) {
   )
 }
 
-function comma_list(field) {
+function comma_list(field, requireFirst) {
+  if (requireFirst) {
+    return seq(
+      field,
+      repeat(
+        seq(',', field)
+      )
+    );
+  }
+
   return optional(
     seq(
       field,
@@ -1475,7 +1477,7 @@ function comma_list(field) {
         seq(',', field)
       ),
     ),
-  )
+  );
 }
 
 function paren_list(field) {

--- a/grammar.js
+++ b/grammar.js
@@ -1312,15 +1312,13 @@ module.exports = grammar({
     order_by: $ => seq(
       $.keyword_order,
       $.keyword_by,
-      $.order_expression,
-    ),
-
-    order_expression: $ => seq(
-      $.order_target,
-      repeat(
-        seq(
-          ',',
-          $.order_target,
+      seq(
+        $.order_target,
+        repeat(
+          seq(
+            ',',
+            $.order_target,
+          ),
         ),
       ),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -1250,7 +1250,7 @@ module.exports = grammar({
       choice(
         seq(
           $.keyword_on,
-          $.join_expression,
+          $._expression,
         ),
         seq(
           $.keyword_using,
@@ -1258,8 +1258,6 @@ module.exports = grammar({
         )
       )
     ),
-
-    join_expression: $ => $._expression,
 
     lateral_join: $ => seq(
       optional(
@@ -1296,10 +1294,8 @@ module.exports = grammar({
 
     where: $ => seq(
       $.keyword_where,
-      $.where_expression,
+      $._expression,
     ),
-
-    where_expression: $ => $._expression,
 
     group_by: $ => seq(
       $.keyword_group,

--- a/grammar.js
+++ b/grammar.js
@@ -474,16 +474,6 @@ module.exports = grammar({
       optional($._alias),
     ),
 
-    expression_list :$ => seq(
-        $._expression,
-        repeat(
-            seq(
-                ',',
-                $._expression,
-            )
-        )
-    ),
-
     _delete_statement: $ => seq(
       $.delete,
       alias($._delete_from, $.from),
@@ -1028,7 +1018,7 @@ module.exports = grammar({
     partition_by: $ => seq(
         $.keyword_partition,
         $.keyword_by,
-        $.expression_list,
+        comma_list($._expression, true),
     ),
 
     frame_definition: $ => seq(
@@ -1266,7 +1256,7 @@ module.exports = grammar({
     group_by: $ => seq(
       $.keyword_group,
       $.keyword_by,
-      $.expression_list,
+      comma_list($._expression, true),
       optional($._having),
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -580,7 +580,7 @@ module.exports = grammar({
             ),
           ),
         ),
-        $.column_list,
+        $.ordered_columns,
       ),
       optional(
         $.where,
@@ -763,7 +763,7 @@ module.exports = grammar({
       choice($.keyword_insert, $.keyword_replace),
       $.keyword_into,
       $.table_reference,
-      optional(alias($._column_list_without_order, $.column_list)),
+      optional(alias($._column_list, $.list)),
       choice(
         seq(
           $.keyword_values,
@@ -773,8 +773,8 @@ module.exports = grammar({
       ),
     ),
 
-    _column_list_without_order: $ => paren_list(alias($._column_without_order, $.column)),
-    _column_without_order: $ => field('name', $.identifier),
+    _column_list: $ => paren_list(alias($._column, $.column), true),
+    _column: $ => field('name', $.identifier),
 
     _update_statement: $ => seq(
       $.update,
@@ -872,23 +872,23 @@ module.exports = grammar({
       $.keyword_constraint,
       field('name', $.identifier),
       $._primary_key,
-      $.column_list,
+      $.ordered_columns,
     ),
 
     _primary_key_constraint: $ => seq(
       $._primary_key,
-      $.column_list,
+      $.ordered_columns,
     ),
 
     _key_constraint: $ => seq(
       $.keyword_key,
       field('name', $.identifier),
-      $.column_list,
+      $.ordered_columns,
     ),
 
-    column_list: $ => paren_list($.column),
+    ordered_columns: $ => paren_list(alias($.ordered_column, $.column), true),
 
-    column: $ => seq(
+    ordered_column: $ => seq(
       field('name', $.identifier),
       optional($.direction),
     ),
@@ -1149,7 +1149,7 @@ module.exports = grammar({
         seq(
           optional($.keyword_as),
           field('table_alias', $._alias_identifier),
-          optional(alias($._column_list_without_order, $.column_list)),
+          optional(alias($._column_list, $.list)),
         ),
       ),
     ),
@@ -1206,7 +1206,7 @@ module.exports = grammar({
         ),
         seq(
           $.keyword_using,
-          alias($._column_list_without_order, $.column_list),
+          alias($._column_list, $.list),
         )
       )
     ),
@@ -1453,10 +1453,10 @@ function comma_list(field, requireFirst) {
   );
 }
 
-function paren_list(field) {
+function paren_list(field, requireFirst) {
   return seq(
     '(',
-    comma_list(field),
+    comma_list(field, requireFirst),
     ')',
   )
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2198,7 +2198,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_expression_list"
+          "name": "_expression"
         },
         {
           "type": "REPEAT",
@@ -2211,61 +2211,10 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_expression_list"
+                "name": "_expression"
               }
             ]
           }
-        }
-      ]
-    },
-    "_expression_list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "literal"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "field"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "parameter"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "case"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "subquery"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "cast"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "implicit_cast"
-              },
-              "named": true,
-              "value": "cast"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "invocation"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "binary_expression"
-            }
-          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4898,15 +4898,27 @@
           ]
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "relation_list"
+              "name": "relation"
             },
             {
-              "type": "SYMBOL",
-              "name": "relation"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "relation"
+                  }
+                ]
+              }
             }
           ]
         },
@@ -4985,31 +4997,6 @@
               "type": "BLANK"
             }
           ]
-        }
-      ]
-    },
-    "relation_list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "relation"
-        },
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "relation"
-              }
-            ]
-          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2672,7 +2672,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "column_list"
+              "name": "ordered_columns"
             }
           ]
         },
@@ -3327,10 +3327,10 @@
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
-                "name": "_column_list_without_order"
+                "name": "_column_list"
               },
               "named": true,
-              "value": "column_list"
+              "value": "list"
             },
             {
               "type": "BLANK"
@@ -3361,7 +3361,7 @@
         }
       ]
     },
-    "_column_list_without_order": {
+    "_column_list": {
       "type": "SEQ",
       "members": [
         {
@@ -3369,45 +3369,37 @@
           "value": "("
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_column_without_order"
-                  },
-                  "named": true,
-                  "value": "column"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "ALIAS",
-                        "content": {
-                          "type": "SYMBOL",
-                          "name": "_column_without_order"
-                        },
-                        "named": true,
-                        "value": "column"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_column"
+              },
+              "named": true,
+              "value": "column"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_column"
+                    },
+                    "named": true,
+                    "value": "column"
+                  }
+                ]
+              }
             }
           ]
         },
@@ -3417,7 +3409,7 @@
         }
       ]
     },
-    "_column_without_order": {
+    "_column": {
       "type": "FIELD",
       "name": "name",
       "content": {
@@ -3914,7 +3906,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "column_list"
+          "name": "ordered_columns"
         }
       ]
     },
@@ -3927,7 +3919,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "column_list"
+          "name": "ordered_columns"
         }
       ]
     },
@@ -3948,11 +3940,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "column_list"
+          "name": "ordered_columns"
         }
       ]
     },
-    "column_list": {
+    "ordered_columns": {
       "type": "SEQ",
       "members": [
         {
@@ -3960,35 +3952,37 @@
           "value": "("
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "column"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "column"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "ordered_column"
+              },
+              "named": true,
+              "value": "column"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "ordered_column"
+                    },
+                    "named": true,
+                    "value": "column"
+                  }
+                ]
+              }
             }
           ]
         },
@@ -3998,7 +3992,7 @@
         }
       ]
     },
-    "column": {
+    "ordered_column": {
       "type": "SEQ",
       "members": [
         {
@@ -5057,10 +5051,10 @@
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "_column_list_without_order"
+                        "name": "_column_list"
                       },
                       "named": true,
-                      "value": "column_list"
+                      "value": "list"
                     },
                     {
                       "type": "BLANK"
@@ -5281,10 +5275,10 @@
                   "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
-                    "name": "_column_list_without_order"
+                    "name": "_column_list"
                   },
                   "named": true,
-                  "value": "column_list"
+                  "value": "list"
                 }
               ]
             }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5542,33 +5542,29 @@
           "name": "keyword_by"
         },
         {
-          "type": "SYMBOL",
-          "name": "order_expression"
-        }
-      ]
-    },
-    "order_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "order_target"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "order_target"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "order_target"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "order_target"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3526,8 +3526,29 @@
           "name": "keyword_set"
         },
         {
-          "type": "SYMBOL",
-          "name": "assignment_list"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "assignment"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "assignment"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -3579,8 +3600,29 @@
           "name": "keyword_set"
         },
         {
-          "type": "SYMBOL",
-          "name": "assignment_list"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "assignment"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "assignment"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -3615,31 +3657,6 @@
               {
                 "type": "SYMBOL",
                 "name": "table_reference"
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "assignment_list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "assignment"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "assignment"
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5326,7 +5326,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "join_expression"
+                  "name": "_expression"
                 }
               ]
             },
@@ -5351,10 +5351,6 @@
           ]
         }
       ]
-    },
-    "join_expression": {
-      "type": "SYMBOL",
-      "name": "_expression"
     },
     "lateral_join": {
       "type": "SEQ",
@@ -5488,13 +5484,9 @@
         },
         {
           "type": "SYMBOL",
-          "name": "where_expression"
+          "name": "_expression"
         }
       ]
-    },
-    "where_expression": {
-      "type": "SYMBOL",
-      "name": "_expression"
     },
     "group_by": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3318,15 +3318,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "insert_expression"
-        }
-      ]
-    },
-    "insert_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
           "name": "table_reference"
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2193,31 +2193,6 @@
         }
       ]
     },
-    "expression_list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_expression"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        }
-      ]
-    },
     "_delete_statement": {
       "type": "SEQ",
       "members": [
@@ -4550,8 +4525,29 @@
           "name": "keyword_by"
         },
         {
-          "type": "SYMBOL",
-          "name": "expression_list"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -5453,8 +5449,29 @@
           "name": "keyword_by"
         },
         {
-          "type": "SYMBOL",
-          "name": "expression_list"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2373,10 +2373,6 @@
           "named": true
         },
         {
-          "type": "relation_list",
-          "named": true
-        },
-        {
           "type": "table_reference",
           "named": true
         },
@@ -3341,21 +3337,6 @@
         },
         {
           "type": "values",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "relation_list",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "relation",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2455,33 +2455,6 @@
       "required": true,
       "types": [
         {
-          "type": "insert_expression",
-          "named": true
-        },
-        {
-          "type": "keyword_insert",
-          "named": true
-        },
-        {
-          "type": "keyword_into",
-          "named": true
-        },
-        {
-          "type": "keyword_replace",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "insert_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
           "type": "column_list",
           "named": true
         },
@@ -2498,7 +2471,19 @@
           "named": true
         },
         {
+          "type": "keyword_insert",
+          "named": true
+        },
+        {
           "type": "keyword_intersect",
+          "named": true
+        },
+        {
+          "type": "keyword_into",
+          "named": true
+        },
+        {
+          "type": "keyword_replace",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1467,21 +1467,6 @@
     }
   },
   {
-    "type": "column_list",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "column",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "comment",
     "named": true,
     "fields": {}
@@ -1529,10 +1514,6 @@
       "required": true,
       "types": [
         {
-          "type": "column_list",
-          "named": true
-        },
-        {
           "type": "keyword_constraint",
           "named": true
         },
@@ -1542,6 +1523,10 @@
         },
         {
           "type": "keyword_primary",
+          "named": true
+        },
+        {
+          "type": "ordered_columns",
           "named": true
         }
       ]
@@ -1659,10 +1644,6 @@
       "required": true,
       "types": [
         {
-          "type": "column_list",
-          "named": true
-        },
-        {
           "type": "identifier",
           "named": true
         },
@@ -1728,6 +1709,10 @@
         },
         {
           "type": "keyword_using",
+          "named": true
+        },
+        {
+          "type": "ordered_columns",
           "named": true
         },
         {
@@ -2455,10 +2440,6 @@
       "required": true,
       "types": [
         {
-          "type": "column_list",
-          "named": true
-        },
-        {
           "type": "from",
           "named": true
         },
@@ -2624,10 +2605,6 @@
         },
         {
           "type": "cast",
-          "named": true
-        },
-        {
-          "type": "column_list",
           "named": true
         },
         {
@@ -2936,6 +2913,10 @@
           "named": true
         },
         {
+          "type": "column",
+          "named": true
+        },
+        {
           "type": "count",
           "named": true
         },
@@ -3164,6 +3145,21 @@
     }
   },
   {
+    "type": "ordered_columns",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "column",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "parameter",
     "named": true,
     "fields": {}
@@ -3282,15 +3278,15 @@
       "required": true,
       "types": [
         {
-          "type": "column_list",
-          "named": true
-        },
-        {
           "type": "invocation",
           "named": true
         },
         {
           "type": "keyword_as",
+          "named": true
+        },
+        {
+          "type": "list",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -564,21 +564,6 @@
     }
   },
   {
-    "type": "assignment_list",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "assignment",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "bigint",
     "named": true,
     "fields": {
@@ -3917,7 +3902,7 @@
       "required": true,
       "types": [
         {
-          "type": "assignment_list",
+          "type": "assignment",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3155,21 +3155,6 @@
           "named": true
         },
         {
-          "type": "order_expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "order_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
           "type": "order_target",
           "named": true
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2192,6 +2192,10 @@
       "required": true,
       "types": [
         {
+          "type": "array",
+          "named": true
+        },
+        {
           "type": "binary_expression",
           "named": true
         },
@@ -2204,11 +2208,19 @@
           "named": true
         },
         {
+          "type": "count",
+          "named": true
+        },
+        {
           "type": "field",
           "named": true
         },
         {
           "type": "invocation",
+          "named": true
+        },
+        {
+          "type": "list",
           "named": true
         },
         {
@@ -2221,6 +2233,14 @@
         },
         {
           "type": "subquery",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "window_function",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2692,7 +2692,31 @@
       "required": true,
       "types": [
         {
+          "type": "array",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
           "type": "column_list",
+          "named": true
+        },
+        {
+          "type": "count",
+          "named": true
+        },
+        {
+          "type": "field",
           "named": true
         },
         {
@@ -2700,7 +2724,7 @@
           "named": true
         },
         {
-          "type": "join_expression",
+          "type": "invocation",
           "named": true
         },
         {
@@ -2736,49 +2760,6 @@
           "named": true
         },
         {
-          "type": "relation",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "join_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "array",
-          "named": true
-        },
-        {
-          "type": "binary_expression",
-          "named": true
-        },
-        {
-          "type": "case",
-          "named": true
-        },
-        {
-          "type": "cast",
-          "named": true
-        },
-        {
-          "type": "count",
-          "named": true
-        },
-        {
-          "type": "field",
-          "named": true
-        },
-        {
-          "type": "invocation",
-          "named": true
-        },
-        {
           "type": "list",
           "named": true
         },
@@ -2788,6 +2769,10 @@
         },
         {
           "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "relation",
           "named": true
         },
         {
@@ -4015,25 +4000,6 @@
       "required": true,
       "types": [
         {
-          "type": "keyword_where",
-          "named": true
-        },
-        {
-          "type": "where_expression",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "where_expression",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
           "type": "array",
           "named": true
         },
@@ -4059,6 +4025,10 @@
         },
         {
           "type": "invocation",
+          "named": true
+        },
+        {
+          "type": "keyword_where",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2169,69 +2169,6 @@
     }
   },
   {
-    "type": "expression_list",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "array",
-          "named": true
-        },
-        {
-          "type": "binary_expression",
-          "named": true
-        },
-        {
-          "type": "case",
-          "named": true
-        },
-        {
-          "type": "cast",
-          "named": true
-        },
-        {
-          "type": "count",
-          "named": true
-        },
-        {
-          "type": "field",
-          "named": true
-        },
-        {
-          "type": "invocation",
-          "named": true
-        },
-        {
-          "type": "list",
-          "named": true
-        },
-        {
-          "type": "literal",
-          "named": true
-        },
-        {
-          "type": "parameter",
-          "named": true
-        },
-        {
-          "type": "subquery",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "window_function",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "field",
     "named": true,
     "fields": {
@@ -2409,10 +2346,6 @@
         },
         {
           "type": "count",
-          "named": true
-        },
-        {
-          "type": "expression_list",
           "named": true
         },
         {
@@ -3259,7 +3192,31 @@
       "required": true,
       "types": [
         {
-          "type": "expression_list",
+          "type": "array",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
+          "type": "count",
+          "named": true
+        },
+        {
+          "type": "field",
+          "named": true
+        },
+        {
+          "type": "invocation",
           "named": true
         },
         {
@@ -3268,6 +3225,30 @@
         },
         {
           "type": "keyword_partition",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "literal",
+          "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "subquery",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "window_function",
           "named": true
         }
       ]

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -120,7 +120,7 @@ CREATE TABLE my_table (
       name: (identifier)
       (keyword_primary)
       (keyword_key)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier)
         (direction (keyword_asc)))
@@ -165,7 +165,7 @@ CREATE TABLE my_table (
      (constraint
       (keyword_key)
       name: (identifier)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier))
        (column
@@ -238,13 +238,13 @@ CREATE TABLE IF NOT EXISTS `addresses` (
      (constraint
       (keyword_primary)
       (keyword_key)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier))))
      (constraint
       (keyword_key)
       name: (identifier)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier)))))))))
 
@@ -310,25 +310,25 @@ CREATE TABLE IF NOT EXISTS `addresses` (
      (constraint
       (keyword_primary)
       (keyword_key)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier))))
      (constraint
       (keyword_key)
       name: (identifier)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier))))
      (constraint
       (keyword_key)
       name: (identifier)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier))))
      (constraint
       (keyword_key)
       name: (identifier)
-      (column_list
+      (ordered_columns
        (column
         name: (identifier))
        (column

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -69,18 +69,17 @@ FROM second;
         (insert
           (keyword_insert)
           (keyword_into)
-          (insert_expression
-            (table_reference
+          (table_reference
+            name: (identifier))
+          (column_list
+            (column
               name: (identifier))
-            (column_list
-              (column
-                name: (identifier))
-              (column
-                name: (identifier)))
-            (keyword_values)
-            (list
-              (literal)
-              (literal))))
+            (column
+              name: (identifier)))
+          (keyword_values)
+          (list
+            (literal)
+            (literal)))
         (returning
           (keyword_returning)
           (select_expression

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -71,7 +71,7 @@ FROM second;
           (keyword_into)
           (table_reference
             name: (identifier))
-          (column_list
+          (list
             (column
               name: (identifier))
             (column

--- a/test/corpus/delete.txt
+++ b/test/corpus/delete.txt
@@ -75,11 +75,10 @@ LIMIT 4;
    (order_by
     (keyword_order)
     (keyword_by)
-    (order_expression
-     (order_target
+    (order_target
       (field name: (identifier))
       (direction
-       (keyword_desc)))))
+       (keyword_desc))))
    (limit
     (keyword_limit)
     (literal)))))

--- a/test/corpus/delete.txt
+++ b/test/corpus/delete.txt
@@ -103,7 +103,6 @@ WHERE id = 9;
     name: (identifier))
    (where
     (keyword_where)
-    (where_expression
-     (binary_expression
+    (binary_expression
       left: (field name: (identifier))
-      right: (literal)))))))
+      right: (literal))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -22,10 +22,9 @@ WHERE m.is_not_deleted;
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (field
-            table_alias: (identifier)
-            name: (identifier)))))))
+        (field
+          table_alias: (identifier)
+          name: (identifier))))))
 
 ================================================================================
 Multiple Field Predicates
@@ -51,15 +50,14 @@ WHERE m.is_not_deleted AND m.is_visible;
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            operator: (keyword_and)
-            right: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          operator: (keyword_and)
+          right: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Single Unary Predicate
@@ -85,12 +83,11 @@ WHERE NOT m.is_not_deleted;
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (unary_expression
-            operator: (keyword_not)
-            operand: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (unary_expression
+          operator: (keyword_not)
+          operand: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Multiple Unary Predicates
@@ -117,19 +114,18 @@ WHERE NOT m.is_not_deleted
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (unary_expression
-              operator: (keyword_not)
-              operand: (field
-                table_alias: (identifier)
-                name: (identifier)))
-            operator: (keyword_and)
-            right: (unary_expression
-              operator: (keyword_not)
-              operand: (field
-                table_alias: (identifier)
-                name: (identifier)))))))))
+        (binary_expression
+          left: (unary_expression
+            operator: (keyword_not)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier)))
+          operator: (keyword_and)
+          right: (unary_expression
+            operator: (keyword_not)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
 
 ================================================================================
 Mixed Predicate types
@@ -158,21 +154,14 @@ WHERE m.status = "success"
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
+        (binary_expression
+          left: (binary_expression
             left: (binary_expression
               left: (binary_expression
-                left: (binary_expression
-                  left: (field
-                    table_alias: (identifier)
-                    name: (identifier))
-                  right: (literal))
-                operator: (keyword_and)
-                right: (binary_expression
-                  left: (field
-                    table_alias: (identifier)
-                    name: (identifier))
-                  right: (literal)))
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal))
               operator: (keyword_and)
               right: (binary_expression
                 left: (field
@@ -180,9 +169,15 @@ WHERE m.status = "success"
                   name: (identifier))
                 right: (literal)))
             operator: (keyword_and)
-            right: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+            right: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (literal)))
+          operator: (keyword_and)
+          right: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Disjunctive Predicate
@@ -211,31 +206,30 @@ WHERE m.status = "success"
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
+        (binary_expression
+          left: (binary_expression
             left: (binary_expression
-              left: (binary_expression
-                left: (field
-                  table_alias: (identifier)
-                  name: (identifier))
-                right: (literal))
-              operator: (keyword_and)
-              right: (binary_expression
-                left: (field
-                  table_alias: (identifier)
-                  name: (identifier))
-                right: (literal)))
-            operator: (keyword_or)
-            right: (binary_expression
-              left: (binary_expression
-                left: (field
-                  table_alias: (identifier)
-                  name: (identifier))
-                right: (literal))
-              operator: (keyword_and)
-              right: (field
+              left: (field
                 table_alias: (identifier)
-                name: (identifier)))))))))
+                name: (identifier))
+              right: (literal))
+            operator: (keyword_and)
+            right: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (literal)))
+          operator: (keyword_or)
+          right: (binary_expression
+            left: (binary_expression
+              left: (field
+                table_alias: (identifier)
+                name: (identifier))
+              right: (literal))
+            operator: (keyword_and)
+            right: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
 
 ================================================================================
 Field Predicate w/ unary predicate
@@ -261,12 +255,11 @@ WHERE NOT m.is_deleted;
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (unary_expression
-            operator: (keyword_not)
-            operand: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (unary_expression
+          operator: (keyword_not)
+          operand: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Field Predicate w/ anonymous unary predicate
@@ -292,12 +285,11 @@ WHERE !m.is_deleted;
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (unary_expression
-            operator: (bang)
-            operand: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (unary_expression
+          operator: (bang)
+          operand: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Field Predicate w/ multiple unary predicate
@@ -324,19 +316,18 @@ WHERE NOT m.is_deleted
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (unary_expression
-              operator: (keyword_not)
-              operand: (field
-                table_alias: (identifier)
-                name: (identifier)))
-            operator: (keyword_and)
-            right: (unary_expression
-              operator: (keyword_not)
-              operand: (field
-                table_alias: (identifier)
-                name: (identifier)))))))))
+        (binary_expression
+          left: (unary_expression
+            operator: (keyword_not)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier)))
+          operator: (keyword_and)
+          right: (unary_expression
+            operator: (keyword_not)
+            operand: (field
+              table_alias: (identifier)
+              name: (identifier))))))))
 
 ================================================================================
 IS DISTINCT FROM
@@ -361,15 +352,14 @@ WHERE col IS DISTINCT FROM NULL;
           (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            (field
-              (identifier))
-            (keyword_is)
-            (keyword_distinct)
-            (keyword_from)
-            (literal
-              (keyword_null))))))))
+        (binary_expression
+          (field
+            (identifier))
+          (keyword_is)
+          (keyword_distinct)
+          (keyword_from)
+          (literal
+            (keyword_null)))))))
 
 ================================================================================
 IS NOT DISTINCT FROM
@@ -394,16 +384,15 @@ WHERE col IS NOT DISTINCT FROM NULL;
           (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            (field
-              (identifier))
-            (keyword_is)
-            (keyword_not)
-            (keyword_distinct)
-            (keyword_from)
-            (literal
-              (keyword_null))))))))
+        (binary_expression
+          (field
+            (identifier))
+          (keyword_is)
+          (keyword_not)
+          (keyword_distinct)
+          (keyword_from)
+          (literal
+            (keyword_null)))))))
 
 ================================================================================
 Predicates with keywords
@@ -429,23 +418,22 @@ WHERE id IS NOT NULL
           name: (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (binary_expression
-              left: (field
-                name: (identifier))
-              operator: (is_not
-                (keyword_is)
-                (keyword_not))
-              right: (literal
-                (keyword_null)))
-            operator: (keyword_and)
-            right: (binary_expression
-              left: (field
-                name: (identifier))
-              operator: (keyword_is)
-              right: (literal
-                (keyword_null)))))))))
+        (binary_expression
+          left: (binary_expression
+            left: (field
+              name: (identifier))
+            operator: (is_not
+              (keyword_is)
+              (keyword_not))
+            right: (literal
+              (keyword_null)))
+          operator: (keyword_and)
+          right: (binary_expression
+            left: (field
+              name: (identifier))
+            operator: (keyword_is)
+            right: (literal
+              (keyword_null))))))))
 
 ================================================================================
 Complex Predicates
@@ -473,18 +461,17 @@ WHERE m.id > 4 AND id < 3;
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (binary_expression
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (literal))
-            operator: (keyword_and)
-            right: (binary_expression
-              left: (field
-                name: (identifier))
-              right: (literal))))))))
+        (binary_expression
+          left: (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (literal))
+          operator: (keyword_and)
+          right: (binary_expression
+            left: (field
+              name: (identifier))
+            right: (literal)))))))
 
 ================================================================================
 Where with pattern matching
@@ -516,34 +503,33 @@ WHERE
           name: (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
+        (binary_expression
+          left: (binary_expression
             left: (binary_expression
               left: (binary_expression
-                left: (binary_expression
-                  left: (field
-                    name: (identifier))
-                  operator: (keyword_like)
-                  right: (literal))
-                operator: (keyword_and)
-                right: (binary_expression
-                  left: (field
-                    name: (identifier))
-                  operator: (keyword_not)
-                  operator: (keyword_like)
-                  right: (literal)))
+                left: (field
+                  name: (identifier))
+                operator: (keyword_like)
+                right: (literal))
               operator: (keyword_and)
               right: (binary_expression
                 left: (field
                   name: (identifier))
-                operator: (keyword_similar)
-                operator: (keyword_to)
+                operator: (keyword_not)
+                operator: (keyword_like)
                 right: (literal)))
             operator: (keyword_and)
             right: (binary_expression
               left: (field
                 name: (identifier))
-              operator: (keyword_not)
               operator: (keyword_similar)
               operator: (keyword_to)
-              right: (literal))))))))
+              right: (literal)))
+          operator: (keyword_and)
+          right: (binary_expression
+            left: (field
+              name: (identifier))
+            operator: (keyword_not)
+            operator: (keyword_similar)
+            operator: (keyword_to)
+            right: (literal)))))))

--- a/test/corpus/group_by.txt
+++ b/test/corpus/group_by.txt
@@ -30,9 +30,8 @@ HAVING other_id > 10;
       (group_by
         (keyword_group)
         (keyword_by)
-        (expression_list
-          (field
-            name: (identifier)))
+        (field
+          name: (identifier))
         (keyword_having)
         (binary_expression
           left: (field
@@ -70,8 +69,7 @@ HAVING other_id > 10;
       (group_by
         (keyword_group)
         (keyword_by)
-        (expression_list
-          (literal))
+        (literal)
         (keyword_having)
         (binary_expression
           left: (field
@@ -112,10 +110,9 @@ HAVING other_id > 10;
       (group_by
         (keyword_group)
         (keyword_by)
-        (expression_list
-          (literal)
-          (field
-            name: (identifier)))
+        (literal)
+        (field
+          name: (identifier))
         (keyword_having)
         (binary_expression
           left: (field
@@ -154,9 +151,8 @@ HAVING COUNT(*) = 2;
       (group_by
         (keyword_group)
         (keyword_by)
-        (expression_list
-          (field
-            (identifier)))
+        (field
+          (identifier))
         (keyword_having)
         (binary_expression
           (count

--- a/test/corpus/index.txt
+++ b/test/corpus/index.txt
@@ -53,9 +53,8 @@ WHERE tab.col > 10;
             (keyword_asc))))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            (field
-              (identifier)
-              (identifier))
-            (literal)))))))
+        (binary_expression
+          (field
+            (identifier)
+            (identifier))
+          (literal))))))

--- a/test/corpus/index.txt
+++ b/test/corpus/index.txt
@@ -14,7 +14,7 @@ CREATE INDEX ON tab(col);
       (keyword_on)
       (table_reference
         (identifier))
-      (column_list
+      (ordered_columns
         (column
           (identifier))))))
 
@@ -46,7 +46,7 @@ WHERE tab.col > 10;
         (identifier))
       (keyword_using)
       (keyword_hash)
-      (column_list
+      (ordered_columns
         (column
           (identifier)
           (direction

--- a/test/corpus/insert.txt
+++ b/test/corpus/insert.txt
@@ -12,14 +12,13 @@ VALUES('foo','bar', 3);
     (insert
       (keyword_insert)
       (keyword_into)
-      (insert_expression
-        (table_reference
-          name: (identifier))
-        (keyword_values)
-        (list
-          (literal)
-          (literal)
-          (literal))))))
+      (table_reference
+        name: (identifier))
+      (keyword_values)
+      (list
+        (literal)
+        (literal)
+        (literal)))))
 
 ================================================================================
 Simple insert with column ordering
@@ -35,21 +34,20 @@ VALUES ('foo', 123, '2020');
     (insert
       (keyword_replace)
       (keyword_into)
-      (insert_expression
-        (table_reference
+      (table_reference
+        name: (identifier))
+      (column_list
+        (column
           name: (identifier))
-        (column_list
-          (column
-            name: (identifier))
-          (column
-            name: (identifier))
-          (column
-            name: (identifier)))
-        (keyword_values)
-        (list
-          (literal)
-          (literal)
-          (literal))))))
+        (column
+          name: (identifier))
+        (column
+          name: (identifier)))
+      (keyword_values)
+      (list
+        (literal)
+        (literal)
+        (literal)))))
 
 ================================================================================
 Insert-select
@@ -66,33 +64,32 @@ FROM my_other_table;
     (insert
       (keyword_insert)
       (keyword_into)
-      (insert_expression
-        (table_reference
+      (table_reference
+        name: (identifier))
+      (column_list
+        (column
           name: (identifier))
-        (column_list
-          (column
-            name: (identifier))
-          (column
-            name: (identifier))
-          (column
-            name: (identifier)))
-        (select
-          (keyword_select)
-          (select_expression
-            (term
-              value: (field
-                name: (identifier)))
-            (term
-              value: (field
-                name: (identifier)))
-            (term
-              value: (field
-                name: (identifier)))))
-        (from
-          (keyword_from)
-          (relation
-            (table_reference
-              name: (identifier))))))))
+        (column
+          name: (identifier))
+        (column
+          name: (identifier)))
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (field
+              name: (identifier)))
+          (term
+            value: (field
+              name: (identifier)))
+          (term
+            value: (field
+              name: (identifier)))))
+      (from
+        (keyword_from)
+        (relation
+          (table_reference
+            name: (identifier)))))))
 
 ================================================================================
 Insert returning
@@ -109,14 +106,13 @@ RETURNING *;
     (insert
       (keyword_insert)
       (keyword_into)
-      (insert_expression
-        (table_reference
-          name: (identifier))
-        (keyword_values)
-        (list
-          (literal)
-          (literal)
-          (literal))))
+      (table_reference
+        name: (identifier))
+      (keyword_values)
+      (list
+        (literal)
+        (literal)
+        (literal)))
     (returning
       (keyword_returning)
       (select_expression
@@ -137,14 +133,13 @@ RETURNING id;
     (insert
       (keyword_insert)
       (keyword_into)
-      (insert_expression
-        (table_reference
-          name: (identifier))
-        (keyword_values)
-        (list
-          (literal)
-          (literal)
-          (literal))))
+      (table_reference
+        name: (identifier))
+      (keyword_values)
+      (list
+        (literal)
+        (literal)
+        (literal)))
     (returning
       (keyword_returning)
       (select_expression
@@ -167,14 +162,13 @@ RETURNING id, val1, val2;
     (insert
       (keyword_insert)
       (keyword_into)
-      (insert_expression
-        (table_reference
-          name: (identifier))
-        (keyword_values)
-        (list
-          (literal)
-          (literal)
-          (literal))))
+      (table_reference
+        name: (identifier))
+      (keyword_values)
+      (list
+        (literal)
+        (literal)
+        (literal)))
     (returning
       (keyword_returning)
       (select_expression

--- a/test/corpus/insert.txt
+++ b/test/corpus/insert.txt
@@ -36,7 +36,7 @@ VALUES ('foo', 123, '2020');
       (keyword_into)
       (table_reference
         name: (identifier))
-      (column_list
+      (list
         (column
           name: (identifier))
         (column
@@ -66,7 +66,7 @@ FROM my_other_table;
       (keyword_into)
       (table_reference
         name: (identifier))
-      (column_list
+      (list
         (column
           name: (identifier))
         (column

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -971,7 +971,7 @@ JOIN my_other_table b USING (q, w);
             name: (identifier))
           table_alias: (identifier))
         (keyword_using)
-        (column_list
+        (list
           (column
             name: (identifier))
           (column
@@ -1011,7 +1011,7 @@ JOIN (VALUES (1, 2), (3, 4)) AS v (col1, col2) ON TRUE;
               (literal)))
           (keyword_as)
           table_alias: (identifier)
-          (column_list
+          (list
             (column
               name: (identifier))
             (column
@@ -1969,7 +1969,7 @@ FROM
             (literal)))
         (keyword_as)
         (identifier)
-        (column_list
+        (list
           (column
             (identifier))
           (column
@@ -2014,7 +2014,7 @@ FROM test_data;
                   (keyword_true))))
             (keyword_as)
             (identifier)
-            (column_list
+            (list
               (column
                 (identifier)))))))
     (select

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -1832,23 +1832,22 @@ FROM
         (all_fields)))
     (from
       (keyword_from)
-      (relation_list
-        (relation
-          (table_reference
-            name: (identifier))
-          table_alias: (identifier))
-        (relation
-          (table_reference
-            name: (identifier))
-          table_alias: (identifier))
-        (relation
-          (table_reference
-            name: (identifier))
-          table_alias: (identifier))
-        (relation
-          (table_reference
-            name: (identifier))
-          table_alias: (identifier))))))
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier))
+      (relation
+        (table_reference
+          name: (identifier))
+        table_alias: (identifier)))))
 
 ================================================================================
 Parameterized Queries

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -269,11 +269,10 @@ WHERE id = 4;
           name: (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              name: (identifier))
-            right: (literal)))))))
+        (binary_expression
+          left: (field
+            name: (identifier))
+          right: (literal))))))
 
 ================================================================================
 Simple select with where and string
@@ -300,11 +299,10 @@ WHERE id = "abc";
           name: (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              name: (identifier))
-            right: (literal)))))))
+        (binary_expression
+          left: (field
+            name: (identifier))
+          right: (literal))))))
 
 ================================================================================
 Simple select with IN
@@ -331,14 +329,13 @@ WHERE id IN(1,2);
           name: (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              name: (identifier))
-            operator: (keyword_in)
-            right: (list
-              (literal)
-              (literal))))))))
+        (binary_expression
+          left: (field
+            name: (identifier))
+          operator: (keyword_in)
+          right: (list
+            (literal)
+            (literal)))))))
 
 ================================================================================
 Simple select with IF
@@ -518,11 +515,10 @@ ORDER BY id DESC;
           name: (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              name: (identifier))
-            right: (literal))))
+        (binary_expression
+          left: (field
+            name: (identifier))
+          right: (literal)))
       (order_by
         (keyword_order)
         (keyword_by)
@@ -799,22 +795,20 @@ WHERE b.c_id = 4;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
           (binary_expression
             left: (field
               table_alias: (identifier)
               name: (identifier))
             right: (field
               table_alias: (identifier)
-              name: (identifier)))))
+              name: (identifier))))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (literal)))))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (literal))))))
 
 ================================================================================
 Join with boolean
@@ -843,9 +837,8 @@ JOIN my_other_table ON TRUE;
           (table_reference
             name: (identifier)))
         (keyword_on)
-        (join_expression
-          (literal
-            (keyword_true)))))))
+        (literal
+          (keyword_true))))))
 
 ================================================================================
 Joins with hint
@@ -890,14 +883,13 @@ ON a.id = b.a_id;
           (keyword_join)
           index_name: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Ignore index for join
@@ -936,14 +928,13 @@ ON a.id = b.a_id;
           (keyword_join)
           index_name: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Joins with USING
@@ -1027,9 +1018,8 @@ JOIN (VALUES (1, 2), (3, 4)) AS v (col1, col2) ON TRUE;
             (column
               name: (identifier))))
         (keyword_on)
-        (join_expression
-          (literal
-            (keyword_true)))))))
+        (literal
+          (keyword_true))))))
 
 ================================================================================
 Specific Joins
@@ -1073,14 +1063,13 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier))))
       (join
         (keyword_left)
         (keyword_outer)
@@ -1090,14 +1079,13 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier))))
       (join
         (keyword_right)
         (keyword_join)
@@ -1106,14 +1094,13 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier))))
       (join
         (keyword_right)
         (keyword_outer)
@@ -1123,14 +1110,13 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier))))
       (join
         (keyword_inner)
         (keyword_join)
@@ -1139,14 +1125,13 @@ ON a.id = e.e_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Lateral join
@@ -1275,14 +1260,13 @@ ON a.id = c.a_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier))))
       (join
         (keyword_join)
         (relation
@@ -1290,14 +1274,13 @@ ON a.id = c.a_id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Complex Predicates with order by
@@ -1329,18 +1312,17 @@ ORDER BY m.title, id ASC;
         table_alias: (identifier))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (binary_expression
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (literal))
-            operator: (keyword_and)
-            right: (binary_expression
-              left: (field
-                name: (identifier))
-              right: (literal)))))
+        (binary_expression
+          left: (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (literal))
+          operator: (keyword_and)
+          right: (binary_expression
+            left: (field
+              name: (identifier))
+            right: (literal))))
       (order_by
         (keyword_order)
         (keyword_by)
@@ -1381,11 +1363,10 @@ ORDER BY id DESC NULLS LAST, val USING < NULLS FIRST;
           name: (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              name: (identifier))
-            right: (literal))))
+        (binary_expression
+          left: (field
+            name: (identifier))
+          right: (literal)))
       (order_by
         (keyword_order)
         (keyword_by)
@@ -1746,23 +1727,22 @@ ORDER BY my_table.title, my_table.id;
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (binary_expression
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (field
-                table_alias: (identifier)
-                name: (identifier)))
-            operator: (keyword_and)
-            right: (binary_expression
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (field
-                table_alias: (identifier)
-                name: (identifier))))))
+        (binary_expression
+          left: (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))
+          operator: (keyword_and)
+          right: (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (join
         (keyword_join)
         (relation
@@ -1775,55 +1755,53 @@ ORDER BY my_table.title, my_table.id;
           (keyword_join)
           index_name: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (binary_expression
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (field
-                table_alias: (identifier)
-                name: (identifier)))
-            operator: (keyword_and)
-            right: (binary_expression
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (field
-                table_alias: (identifier)
-                name: (identifier))))))
+        (binary_expression
+          left: (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))
+          operator: (keyword_and)
+          right: (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (field
+              table_alias: (identifier)
+              name: (identifier)))))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
+        (binary_expression
+          left: (binary_expression
             left: (binary_expression
               left: (binary_expression
-                left: (binary_expression
-                  left: (field
-                    table_alias: (identifier)
-                    name: (identifier))
-                  right: (literal))
-                operator: (keyword_and)
-                right: (binary_expression
-                  left: (field
-                    table_alias: (identifier)
-                    name: (identifier))
-                  operator: (keyword_in)
-                  right: (list
-                    (literal))))
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal))
               operator: (keyword_and)
               right: (binary_expression
                 left: (field
                   table_alias: (identifier)
                   name: (identifier))
-                right: (literal)))
+                operator: (keyword_in)
+                right: (list
+                  (literal))))
             operator: (keyword_and)
             right: (binary_expression
               left: (field
                 table_alias: (identifier)
                 name: (identifier))
-              right: (literal
-                (keyword_true))))))
+              right: (literal)))
+          operator: (keyword_and)
+          right: (binary_expression
+            left: (field
+              table_alias: (identifier)
+              name: (identifier))
+            right: (literal
+              (keyword_true)))))
       (order_by
         (keyword_order)
         (keyword_by)
@@ -1899,11 +1877,10 @@ WHERE id = ?;
           (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            (field
-              (identifier))
-            (parameter)))))))
+        (binary_expression
+          (field
+            (identifier))
+          (parameter))))))
 
 ================================================================================
 Parameterized Queries w/ $1 syntax
@@ -1928,11 +1905,10 @@ WHERE id = $12;
           (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            (field
-              (identifier))
-            (parameter)))))))
+        (binary_expression
+          (field
+            (identifier))
+          (parameter))))))
 
 ================================================================================
 Select from aliased subquery
@@ -2138,22 +2114,20 @@ WHERE
             name: (identifier))
           table_alias: (identifier))
         (keyword_on)
-        (join_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (field
-              table_alias: (identifier)
-              name: (identifier)))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (field
+            table_alias: (identifier)
+            name: (identifier))))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            left: (field
-              table_alias: (identifier)
-              name: (identifier))
-            right: (literal)))))))
+        (binary_expression
+          left: (field
+            table_alias: (identifier)
+            name: (identifier))
+          right: (literal))))))
 
 ================================================================================
 Arrays

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -522,12 +522,11 @@ ORDER BY id DESC;
       (order_by
         (keyword_order)
         (keyword_by)
-        (order_expression
-          (order_target
-            (field
-              name: (identifier))
-            (direction
-              (keyword_desc))))))))
+        (order_target
+          (field
+            name: (identifier))
+          (direction
+            (keyword_desc)))))))
 
 ================================================================================
 Simple select with limit
@@ -1326,16 +1325,15 @@ ORDER BY m.title, id ASC;
       (order_by
         (keyword_order)
         (keyword_by)
-        (order_expression
-          (order_target
-            (field
-              table_alias: (identifier)
-              name: (identifier)))
-          (order_target
-            (field
-              name: (identifier))
-            (direction
-              (keyword_asc))))))))
+        (order_target
+          (field
+            table_alias: (identifier)
+            name: (identifier)))
+        (order_target
+          (field
+            name: (identifier))
+          (direction
+            (keyword_asc)))))))
 
 ================================================================================
 Order by with extra directives
@@ -1370,20 +1368,19 @@ ORDER BY id DESC NULLS LAST, val USING < NULLS FIRST;
       (order_by
         (keyword_order)
         (keyword_by)
-        (order_expression
-          (order_target
-            (field
-              name: (identifier))
-            (direction
-              (keyword_desc))
-            (keyword_nulls)
-            (keyword_last))
-          (order_target
-            (field
-              name: (identifier))
-            (keyword_using)
-            (keyword_nulls)
-            (keyword_first)))))))
+        (order_target
+          (field
+            name: (identifier))
+          (direction
+            (keyword_desc))
+          (keyword_nulls)
+          (keyword_last))
+        (order_target
+          (field
+            name: (identifier))
+          (keyword_using)
+          (keyword_nulls)
+          (keyword_first))))))
 
 ================================================================================
 Index hints
@@ -1805,15 +1802,14 @@ ORDER BY my_table.title, my_table.id;
       (order_by
         (keyword_order)
         (keyword_by)
-        (order_expression
-          (order_target
-            (field
-              table_alias: (identifier)
-              name: (identifier)))
-          (order_target
-            (field
-              table_alias: (identifier)
-              name: (identifier))))))))
+        (order_target
+          (field
+            table_alias: (identifier)
+            name: (identifier)))
+        (order_target
+          (field
+            table_alias: (identifier)
+            name: (identifier)))))))
 
 ================================================================================
 Multiple tables in list

--- a/test/corpus/subquery.txt
+++ b/test/corpus/subquery.txt
@@ -26,22 +26,21 @@ WHERE id < (
           (identifier)))
       (where
         (keyword_where)
-        (where_expression
-          (binary_expression
-            (field
-              (identifier))
-            (subquery
-              (select
-                (keyword_select)
-                (select_expression
-                  (term
-                    (field
-                      (identifier)))))
-              (from
-                (keyword_from)
-                (relation
-                  (table_reference
-                    (identifier)))
-                (limit
-                  (keyword_limit)
-                  (literal))))))))))
+        (binary_expression
+          (field
+            (identifier))
+          (subquery
+            (select
+              (keyword_select)
+              (select_expression
+                (term
+                  (field
+                    (identifier)))))
+            (from
+              (keyword_from)
+              (relation
+                (table_reference
+                  (identifier)))
+              (limit
+                (keyword_limit)
+                (literal)))))))))

--- a/test/corpus/transaction.txt
+++ b/test/corpus/transaction.txt
@@ -46,11 +46,10 @@ COMMIT;
     (table_reference
      name: (identifier))
     (keyword_set)
-    (assignment_list
-     (assignment
+    (assignment
       left: (field
         name: (identifier))
-      right: (literal)))))
+      right: (literal))))
  (keyword_commit)))
 
 ==================

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -13,13 +13,12 @@ SET for = foo + 1;
    (keyword_update)
    (table_reference name: (identifier))
    (keyword_set)
-   (assignment_list
-    (assignment
+   (assignment
      left: (field name: (identifier))
      right:
      (binary_expression
       left: (field name: (identifier))
-      right: (literal)))))))
+      right: (literal))))))
 
 ==================
 Simple update with ONLY
@@ -37,13 +36,12 @@ SET for = foo + 1;
    (keyword_only)
    (table_reference name: (identifier))
    (keyword_set)
-   (assignment_list
-    (assignment
+   (assignment
      left: (field name: (identifier))
      right:
      (binary_expression
       left: (field name: (identifier))
-      right: (literal)))))))
+      right: (literal))))))
 
 ==================
 update with multiple assignments
@@ -60,8 +58,7 @@ SET for = foo + 1, col2 = col1;
    (keyword_update)
    (table_reference name: (identifier))
    (keyword_set)
-   (assignment_list
-    (assignment
+   (assignment
      left: (field name: (identifier))
      right:
      (binary_expression
@@ -69,7 +66,7 @@ SET for = foo + 1, col2 = col1;
       right: (literal)))
     (assignment
      left: (field name: (identifier))
-     right: (field name: (identifier)))))))
+     right: (field name: (identifier))))))
 
 ==================
 update with multiple table references
@@ -88,10 +85,9 @@ WHERE items.id=month.item_id;
    (table_reference name: (identifier))
    (table_reference name: (identifier))
    (keyword_set)
-   (assignment_list
-    (assignment
+   (assignment
      left: (field table_alias: (identifier) name: (identifier))
-     right: (field table_alias: (identifier) name: (identifier))))
+     right: (field table_alias: (identifier) name: (identifier)))
    (where
     (keyword_where)
     (binary_expression
@@ -113,8 +109,7 @@ SET ts = now();
    (keyword_update)
    (table_reference name: (identifier))
    (keyword_set)
-   (assignment_list
-    (assignment
+   (assignment
      left: (field name: (identifier))
      right: (invocation
-       name: (identifier)))))))
+       name: (identifier))))))

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -94,10 +94,9 @@ WHERE items.id=month.item_id;
      right: (field table_alias: (identifier) name: (identifier))))
    (where
     (keyword_where)
-    (where_expression
-     (binary_expression
+    (binary_expression
       left: (field table_alias: (identifier) name: (identifier))
-      right: (field table_alias: (identifier) name: (identifier))))))))
+      right: (field table_alias: (identifier) name: (identifier)))))))
 
 ==================
 update with function call

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -83,14 +83,13 @@ FROM tab1;
               (order_by
                 (keyword_order)
                 (keyword_by)
-                (order_expression
-                  (order_target
-                    (field
-                      name: (identifier))
-                    (direction
-                      (keyword_desc))
-                    (keyword_nulls)
-                    (keyword_last)))))))))
+                (order_target
+                  (field
+                    name: (identifier))
+                  (direction
+                    (keyword_desc))
+                  (keyword_nulls)
+                  (keyword_last))))))))
     (from
       (keyword_from)
       (relation
@@ -141,14 +140,13 @@ FROM tab1;
               (order_by
                 (keyword_order)
                 (keyword_by)
-                (order_expression
-                  (order_target
-                    (field
-                      name: (identifier))
-                    (direction
-                      (keyword_desc))
-                    (keyword_nulls)
-                    (keyword_first)))))))))
+                (order_target
+                  (field
+                    name: (identifier))
+                  (direction
+                    (keyword_desc))
+                  (keyword_nulls)
+                  (keyword_first))))))))
     (from
       (keyword_from)
       (relation
@@ -237,10 +235,9 @@ FROM tab1;
               (order_by
                 (keyword_order)
                 (keyword_by)
-                (order_expression
-                  (order_target
-                    (field
-                      name: (identifier)))))))
+                (order_target
+                  (field
+                    name: (identifier))))))
           (keyword_as)
           alias: (identifier))
         (term
@@ -357,10 +354,9 @@ WINDOW win AS (ORDER BY d)
         (order_by
           (keyword_order)
           (keyword_by)
-          (order_expression
-            (order_target
-              (field
-                name: (identifier)))))))))
+          (order_target
+            (field
+              name: (identifier))))))))
 
 ================================================================================
 Window Functions partition order frame
@@ -408,10 +404,9 @@ FROM
               (order_by
                 (keyword_order)
                 (keyword_by)
-                (order_expression
-                  (order_target
-                    (field
-                      name: (identifier)))))
+                (order_target
+                  (field
+                    name: (identifier))))
               (window_frame
                 (keyword_range)
                 (keyword_between)
@@ -476,14 +471,13 @@ FROM
               (order_by
                 (keyword_order)
                 (keyword_by)
-                (order_expression
-                  (order_target
-                    (field
-                      name: (identifier))
-                    (direction
-                      (keyword_asc))
-                    (keyword_nulls)
-                    (keyword_first))))
+                (order_target
+                  (field
+                    name: (identifier))
+                  (direction
+                    (keyword_asc))
+                  (keyword_nulls)
+                  (keyword_first)))
               (window_frame
                 (keyword_rows)
                 (keyword_between)
@@ -612,65 +606,64 @@ FROM
               (order_by
                 (keyword_order)
                 (keyword_by)
-                (order_expression
-                  (order_target
-                    (literal))
-                  (order_target
-                    (field
-                      (identifier)))
-                  (order_target
-                    (parameter))
-                  (order_target
-                    (case
-                      (keyword_case)
-                      (keyword_when)
-                      (binary_expression
-                        (field
-                          (identifier))
-                        (parameter))
-                      (keyword_then)
-                      (literal
-                        (keyword_true))
-                      (keyword_else)
-                      (literal
-                        (keyword_false))
-                      (keyword_end)))
-                  (order_target
-                    (cast
-                      (identifier)
-                      (field
-                        (identifier))
-                      (keyword_as)
-                      (keyword_date)))
-                  (order_target
-                    (cast
-                      (field
-                        (identifier))
-                      (keyword_date)))
-                  (order_target
-                    (subquery
-                      (select
-                        (keyword_select)
-                        (select_expression
-                          (term
-                            (field
-                              (identifier)))))
-                      (from
-                        (keyword_from)
-                        (relation
-                          (table_reference
-                            (identifier))))))
-                  (order_target
-                    (invocation
-                      (identifier)
-                      (field
-                        (identifier))))
-                  (order_target
+                (order_target
+                  (literal))
+                (order_target
+                  (field
+                    (identifier)))
+                (order_target
+                  (parameter))
+                (order_target
+                  (case
+                    (keyword_case)
+                    (keyword_when)
                     (binary_expression
                       (field
                         (identifier))
-                      (field
-                        (identifier)))))))))))
+                      (parameter))
+                    (keyword_then)
+                    (literal
+                      (keyword_true))
+                    (keyword_else)
+                    (literal
+                      (keyword_false))
+                    (keyword_end)))
+                (order_target
+                  (cast
+                    (identifier)
+                    (field
+                      (identifier))
+                    (keyword_as)
+                    (keyword_date)))
+                (order_target
+                  (cast
+                    (field
+                      (identifier))
+                    (keyword_date)))
+                (order_target
+                  (subquery
+                    (select
+                      (keyword_select)
+                      (select_expression
+                        (term
+                          (field
+                            (identifier)))))
+                    (from
+                      (keyword_from)
+                      (relation
+                        (table_reference
+                          (identifier))))))
+                (order_target
+                  (invocation
+                    (identifier)
+                    (field
+                      (identifier))))
+                (order_target
+                  (binary_expression
+                    (field
+                      (identifier))
+                    (field
+                      (identifier))))))))))
     (from
       (keyword_from)
       (relation

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -36,9 +36,8 @@ FROM tab1;
               (partition_by
                 (keyword_partition)
                 (keyword_by)
-                (expression_list
-                  (field
-                    name: (identifier)))))))))
+                (field
+                  name: (identifier))))))))
     (from
       (keyword_from)
       (relation
@@ -134,9 +133,8 @@ FROM tab1;
               (partition_by
                 (keyword_partition)
                 (keyword_by)
-                (expression_list
-                  (field
-                    name: (identifier))))
+                (field
+                  name: (identifier)))
               (order_by
                 (keyword_order)
                 (keyword_by)
@@ -219,9 +217,8 @@ FROM tab1;
               (partition_by
                 (keyword_partition)
                 (keyword_by)
-                (expression_list
-                  (field
-                    name: (identifier))))))
+                (field
+                  name: (identifier)))))
           (keyword_as)
           alias: (identifier))
         (term
@@ -290,9 +287,8 @@ WINDOW window_def AS (PARTITION BY y);
         (partition_by
           (keyword_partition)
           (keyword_by)
-          (expression_list
-            (field
-              name: (identifier))))))))
+          (field
+            name: (identifier)))))))
 
 ================================================================================
 Window Functions one inlined one named
@@ -327,9 +323,8 @@ WINDOW win AS (ORDER BY d)
               (partition_by
                 (keyword_partition)
                 (keyword_by)
-                (expression_list
-                  (field
-                    name: (identifier))))))
+                (field
+                  name: (identifier)))))
           (keyword_as)
           alias: (identifier))
         (term
@@ -398,9 +393,8 @@ FROM
               (partition_by
                 (keyword_partition)
                 (keyword_by)
-                (expression_list
-                  (field
-                    name: (identifier))))
+                (field
+                  name: (identifier)))
               (order_by
                 (keyword_order)
                 (keyword_by)
@@ -463,11 +457,10 @@ FROM
               (partition_by
                 (keyword_partition)
                 (keyword_by)
-                (expression_list
-                  (field
-                    name: (identifier))
-                  (field
-                    name: (identifier))))
+                (field
+                  name: (identifier))
+                (field
+                  name: (identifier)))
               (order_by
                 (keyword_order)
                 (keyword_by)
@@ -553,8 +546,7 @@ FROM
               (partition_by
                 (keyword_partition)
                 (keyword_by)
-                (expression_list
-                  (literal)
+                (literal)
                   (field
                     (identifier))
                   (parameter)
@@ -602,7 +594,7 @@ FROM
                     (field
                       (identifier))
                     (field
-                      (identifier)))))
+                      (identifier))))
               (order_by
                 (keyword_order)
                 (keyword_by)


### PR DESCRIPTION
Some more redundancies; feel free to exercise a line item veto here, I've itemized the commits.

I wanted to pull these out because they wrap _expressions at fixed or trivially findable positions in their respective clauses:

- join_expression: after `on`
- where_expression: always second
- order_expression: always third
- expression_list: always third (in partition and group)
- assignment_list: after `set`
- insert_expression: after `into`, basically split inserts in half

on column_list it just felt wrong that the most common use was anonymized and aliased while the somewhat obscure ordered syntax (not actually used in order_by, which has its own thing going on!) got pride of place. I've changed the alias to a more uniform `list`.