### PR TITLE
Various improvements: aggregate functions, insert set syntax, & update join syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1016,21 +1016,22 @@ module.exports = grammar({
     count: $ => seq(
       field('name', alias($.keyword_count, $.identifier)),
       '(',
-      seq(
-        optional($.keyword_distinct),
-        field('parameter', choice($._expression, $.all_fields)),
-      ),
+      $._aggregate_expression,
       ')',
     ),
 
     group_concat: $ => seq(
       field('name', $.keyword_group_concat),
       '(',
-      optional($.keyword_distinct),
-      field('parameter', choice($._expression)),
-      optional($.order_by),
+      $._aggregate_expression,
       optional(seq($.keyword_separator, alias($._literal_string, $.literal))),
       ')',
+    ),
+
+    _aggregate_expression: $ => seq(
+      optional($.keyword_distinct),
+      field('parameter', choice($._expression, $.all_fields)),
+      optional($.order_by),
     ),
 
     invocation: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -802,11 +802,29 @@ module.exports = grammar({
     update: $ => seq(
       $.keyword_update,
       optional($.keyword_only),
-      comma_list($.relation, true),
-      repeat($.join),
-      $.keyword_set,
-      comma_list($.assignment, true),
-      optional($.where),
+      choice(
+        $._mysql_update_statement,
+        $._postgres_update_statement,
+      ),
+    ),
+
+    _mysql_update_statement: $ => prec(0,
+      seq(
+        comma_list($.relation, true),
+        repeat($.join),
+        $.keyword_set,
+        comma_list($.assignment, true),
+        optional($.where),
+      ),
+    ),
+
+    _postgres_update_statement: $ => prec(1,
+      seq(
+        $.relation,
+        $.keyword_set,
+        comma_list($.assignment, true),
+        optional($.from),
+      ),
     ),
 
     assignment: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -801,36 +801,12 @@ module.exports = grammar({
 
     update: $ => seq(
       $.keyword_update,
-      choice(
-        $._single_table_update,
-        $._multi_table_update,
-      ),
-    ),
-
-    _single_table_update: $ => seq(
-      optional(
-        $.keyword_only,
-      ),
-      $.table_reference,
+      optional($.keyword_only),
+      comma_list($.relation, true),
+      repeat($.join),
       $.keyword_set,
       comma_list($.assignment, true),
       optional($.where),
-      optional($.order_by),
-      optional($.limit),
-    ),
-
-    _multi_table_update: $ => seq(
-      $._table_references,
-      $.keyword_set,
-      comma_list($.assignment, true),
-      optional($.where),
-    ),
-
-    _table_references: $ => seq(
-      $.table_reference,
-      repeat1(
-        seq(',', $.table_reference),
-      ),
     ),
 
     assignment: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -767,14 +767,26 @@ module.exports = grammar({
       choice($.keyword_insert, $.keyword_replace),
       $.keyword_into,
       $.table_reference,
+      choice(
+        $._insert_values,
+        $._insert_set,
+      ),
+    ),
+
+    _insert_values: $ => seq(
       optional(alias($._column_list, $.list)),
       choice(
         seq(
           $.keyword_values,
-          $.list,
+          comma_list($.list, true),
         ),
         $._select_statement,
       ),
+    ),
+
+    _insert_set: $ => seq(
+      $.keyword_set,
+      comma_list($.assignment, true),
     ),
 
     _column_list: $ => paren_list(alias($._column, $.column), true),

--- a/grammar.js
+++ b/grammar.js
@@ -79,6 +79,8 @@ module.exports = grammar({
     keyword_constraint: _ => make_keyword("constraint"),
     keyword_cast: _ => make_keyword("cast"),
     keyword_count: _ => make_keyword("count"),
+    keyword_group_concat: _ => make_keyword("group_concat"),
+    keyword_separator: _ => make_keyword("separator"),
     keyword_max: _ => make_keyword("max"),
     keyword_min: _ => make_keyword("min"),
     keyword_avg: _ => make_keyword("avg"),
@@ -1012,6 +1014,11 @@ module.exports = grammar({
       ')',
     ),
 
+    _aggregate_function: $ => choice(
+      $.group_concat,
+      $.count,
+    ),
+
     count: $ => seq(
       field('name', alias($.keyword_count, $.identifier)),
       '(',
@@ -1019,6 +1026,16 @@ module.exports = grammar({
         optional($.keyword_distinct),
         field('parameter', choice($._expression, $.all_fields)),
       ),
+      ')',
+    ),
+
+    group_concat: $ => seq(
+      field('name', $.keyword_group_concat),
+      '(',
+      optional($.keyword_distinct),
+      field('parameter', choice($._expression)),
+      optional($.order_by),
+      optional(seq($.keyword_separator, alias($._literal_string, $.literal))),
       ')',
     ),
 
@@ -1334,7 +1351,7 @@ module.exports = grammar({
         $.subquery,
         $.cast,
         alias($.implicit_cast, $.cast),
-        $.count,
+        $._aggregate_function,
         $.invocation,
         $.binary_expression,
         $.unary_expression,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3577,79 +3577,155 @@
           ]
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "relation"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "relation"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "join"
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "keyword_set"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "assignment"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "assignment"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "where"
+              "name": "_mysql_update_statement"
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "_postgres_update_statement"
             }
           ]
         }
       ]
+    },
+    "_mysql_update_statement": {
+      "type": "PREC",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "relation"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "relation"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "join"
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "keyword_set"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "assignment"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "where"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_postgres_update_statement": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "relation"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "keyword_set"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "assignment"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "assignment"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "from"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "assignment": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -190,6 +190,14 @@
       "type": "PATTERN",
       "value": "count|COUNT"
     },
+    "keyword_group_concat": {
+      "type": "PATTERN",
+      "value": "group_concat|GROUP_CONCAT"
+    },
+    "keyword_separator": {
+      "type": "PATTERN",
+      "value": "separator|SEPARATOR"
+    },
     "keyword_max": {
       "type": "PATTERN",
       "value": "max|MAX"
@@ -4482,6 +4490,19 @@
         }
       ]
     },
+    "_aggregate_function": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "group_concat"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "count"
+        }
+      ]
+    },
     "count": {
       "type": "SEQ",
       "members": [
@@ -4533,6 +4554,90 @@
                   }
                 ]
               }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "group_concat": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "keyword_group_concat"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_distinct"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "parameter",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "order_by"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_separator"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_literal_string"
+                  },
+                  "named": true,
+                  "value": "literal"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
             }
           ]
         },
@@ -5833,7 +5938,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "count"
+            "name": "_aggregate_function"
           },
           {
             "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3362,6 +3362,24 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_insert_values"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_insert_set"
+            }
+          ]
+        }
+      ]
+    },
+    "_insert_values": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
@@ -3386,14 +3404,69 @@
                   "name": "keyword_values"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "list"
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "list"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "list"
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             },
             {
               "type": "SYMBOL",
               "name": "_select_statement"
+            }
+          ]
+        }
+      ]
+    },
+    "_insert_set": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_set"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "assignment"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "assignment"
+                  }
+                ]
+              }
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3569,24 +3569,6 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_single_table_update"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_multi_table_update"
-            }
-          ]
-        }
-      ]
-    },
-    "_single_table_update": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
               "name": "keyword_only"
             },
             {
@@ -3595,19 +3577,11 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "table_reference"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "keyword_set"
-        },
-        {
           "type": "SEQ",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "assignment"
+              "name": "relation"
             },
             {
               "type": "REPEAT",
@@ -3620,7 +3594,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "assignment"
+                    "name": "relation"
                   }
                 ]
               }
@@ -3628,115 +3602,52 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "where"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "order_by"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "limit"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "_multi_table_update": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_table_references"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "keyword_set"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "assignment"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "assignment"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "where"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "_table_references": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "table_reference"
-        },
-        {
-          "type": "REPEAT1",
+          "type": "REPEAT",
           "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "table_reference"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "join"
           }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_set"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "assignment"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "assignment"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "where"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4511,38 +4511,8 @@
           "value": "("
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "keyword_distinct"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "FIELD",
-              "name": "parameter",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "all_fields"
-                  }
-                ]
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_aggregate_expression"
         },
         {
           "type": "STRING",
@@ -4566,41 +4536,8 @@
           "value": "("
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "keyword_distinct"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "FIELD",
-          "name": "parameter",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_expression"
-              }
-            ]
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "order_by"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_aggregate_expression"
         },
         {
           "type": "CHOICE",
@@ -4631,6 +4568,52 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "_aggregate_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_distinct"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "parameter",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "all_fields"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "order_by"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -250,6 +250,10 @@
           "named": true
         },
         {
+          "type": "group_concat",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -455,6 +459,10 @@
           "named": true
         },
         {
+          "type": "group_concat",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -529,6 +537,10 @@
           },
           {
             "type": "field",
+            "named": true
+          },
+          {
+            "type": "group_concat",
             "named": true
           },
           {
@@ -619,6 +631,10 @@
           },
           {
             "type": "field",
+            "named": true
+          },
+          {
+            "type": "group_concat",
             "named": true
           },
           {
@@ -782,6 +798,10 @@
             "named": true
           },
           {
+            "type": "group_concat",
+            "named": true
+          },
+          {
             "type": "invocation",
             "named": true
           },
@@ -843,6 +863,10 @@
         },
         {
           "type": "field",
+          "named": true
+        },
+        {
+          "type": "group_concat",
           "named": true
         },
         {
@@ -943,6 +967,10 @@
             "named": true
           },
           {
+            "type": "group_concat",
+            "named": true
+          },
+          {
             "type": "invocation",
             "named": true
           },
@@ -1019,6 +1047,10 @@
         },
         {
           "type": "float",
+          "named": true
+        },
+        {
+          "type": "group_concat",
           "named": true
         },
         {
@@ -1591,6 +1623,10 @@
           },
           {
             "type": "field",
+            "named": true
+          },
+          {
+            "type": "group_concat",
             "named": true
           },
           {
@@ -2361,6 +2397,10 @@
           "named": true
         },
         {
+          "type": "group_concat",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -2398,6 +2438,106 @@
         },
         {
           "type": "window_function",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "group_concat",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "keyword_group_concat",
+            "named": true
+          }
+        ]
+      },
+      "parameter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "array",
+            "named": true
+          },
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "cast",
+            "named": true
+          },
+          {
+            "type": "count",
+            "named": true
+          },
+          {
+            "type": "field",
+            "named": true
+          },
+          {
+            "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "invocation",
+            "named": true
+          },
+          {
+            "type": "list",
+            "named": true
+          },
+          {
+            "type": "literal",
+            "named": true
+          },
+          {
+            "type": "parameter",
+            "named": true
+          },
+          {
+            "type": "subquery",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          },
+          {
+            "type": "window_function",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "keyword_distinct",
+          "named": true
+        },
+        {
+          "type": "keyword_separator",
+          "named": true
+        },
+        {
+          "type": "literal",
+          "named": true
+        },
+        {
+          "type": "order_by",
           "named": true
         }
       ]
@@ -2564,6 +2704,10 @@
             "named": true
           },
           {
+            "type": "group_concat",
+            "named": true
+          },
+          {
             "type": "invocation",
             "named": true
           },
@@ -2644,6 +2788,10 @@
           },
           {
             "type": "field",
+            "named": true
+          },
+          {
+            "type": "group_concat",
             "named": true
           },
           {
@@ -2837,6 +2985,10 @@
           "named": true
         },
         {
+          "type": "group_concat",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -2964,6 +3116,10 @@
         },
         {
           "type": "field",
+          "named": true
+        },
+        {
+          "type": "group_concat",
           "named": true
         },
         {
@@ -3209,6 +3365,10 @@
           "named": true
         },
         {
+          "type": "group_concat",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -3305,6 +3465,10 @@
         },
         {
           "type": "field",
+          "named": true
+        },
+        {
+          "type": "group_concat",
           "named": true
         },
         {
@@ -3816,6 +3980,10 @@
             "named": true
           },
           {
+            "type": "group_concat",
+            "named": true
+          },
+          {
             "type": "invocation",
             "named": true
           },
@@ -3918,6 +4086,10 @@
           },
           {
             "type": "field",
+            "named": true
+          },
+          {
+            "type": "group_concat",
             "named": true
           },
           {
@@ -4084,6 +4256,10 @@
           },
           {
             "type": "field",
+            "named": true
+          },
+          {
+            "type": "group_concat",
             "named": true
           },
           {
@@ -4589,6 +4765,10 @@
     "named": true
   },
   {
+    "type": "keyword_group_concat",
+    "named": true
+  },
+  {
     "type": "keyword_groups",
     "named": true
   },
@@ -4806,6 +4986,10 @@
   },
   {
     "type": "keyword_select",
+    "named": true
+  },
+  {
+    "type": "keyword_separator",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4151,6 +4151,10 @@
           "named": true
         },
         {
+          "type": "join",
+          "named": true
+        },
+        {
           "type": "keyword_only",
           "named": true
         },
@@ -4163,15 +4167,7 @@
           "named": true
         },
         {
-          "type": "limit",
-          "named": true
-        },
-        {
-          "type": "order_by",
-          "named": true
-        },
-        {
-          "type": "table_reference",
+          "type": "relation",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1661,11 +1661,15 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
           "type": "keyword_distinct",
+          "named": true
+        },
+        {
+          "type": "order_by",
           "named": true
         }
       ]
@@ -2461,6 +2465,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "all_fields",
+            "named": true
+          },
           {
             "type": "array",
             "named": true

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2463,6 +2463,10 @@
       "required": true,
       "types": [
         {
+          "type": "assignment",
+          "named": true
+        },
+        {
           "type": "from",
           "named": true
         },
@@ -2488,6 +2492,10 @@
         },
         {
           "type": "keyword_replace",
+          "named": true
+        },
+        {
+          "type": "keyword_set",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4151,6 +4151,10 @@
           "named": true
         },
         {
+          "type": "from",
+          "named": true
+        },
+        {
           "type": "join",
           "named": true
         },

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -135,3 +135,77 @@ select col_has_check(
                 (literal)
                 (keyword_name)))
             parameter: (literal)))))))
+
+================================================================================
+GROUP CONCAT
+================================================================================
+
+SELECT GROUP_CONCAT(uid SEPARATOR ",")
+FROM some_table
+GROUP BY some_field;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (group_concat
+            (keyword_group_concat)
+            (field
+              (identifier))
+            (keyword_separator)
+            (literal)))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier))) (group_by
+        (keyword_group)
+        (keyword_by)
+        (field
+          (identifier))))))
+
+================================================================================
+GROUP CONCAT with all optional fields
+================================================================================
+
+SELECT GROUP_CONCAT(DISTINCT uid ORDER BY uid DESC SEPARATOR ",")
+FROM some_table
+GROUP BY some_field;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (group_concat
+            (keyword_group_concat)
+            (keyword_distinct)
+            (field
+              (identifier))
+            (order_by
+              (keyword_order)
+              (keyword_by)
+              (order_target
+                (field
+                  (identifier))
+                (direction
+                  (keyword_desc))))
+            (keyword_separator)
+            (literal)))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier)))
+      (group_by
+        (keyword_group)
+        (keyword_by)
+        (field
+          (identifier))))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -137,6 +137,38 @@ select col_has_check(
             parameter: (literal)))))))
 
 ================================================================================
+Count with postgres style aggregate expression
+================================================================================
+
+SELECT COUNT(DISTINCT uid ORDER BY uid)
+FROM table_a;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (count
+            (identifier)
+            (keyword_distinct)
+            (field
+              (identifier))
+            (order_by
+              (keyword_order)
+              (keyword_by)
+              (order_target
+                (field
+                  (identifier))))))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier))))))
+
+================================================================================
 GROUP CONCAT
 ================================================================================
 
@@ -162,7 +194,8 @@ GROUP BY some_field;
       (keyword_from)
       (relation
         (table_reference
-          (identifier))) (group_by
+          (identifier)))
+      (group_by
         (keyword_group)
         (keyword_by)
         (field

--- a/test/corpus/insert.txt
+++ b/test/corpus/insert.txt
@@ -181,3 +181,53 @@ RETURNING id, val1, val2;
         (term
           value: (field
             name: (identifier)))))))
+
+================================================================================
+Insert with multple values
+================================================================================
+
+INSERT INTO some_table
+  (field)
+VALUES
+  ("String value"),
+  ("String value");
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (insert
+      (keyword_insert)
+      (keyword_into)
+      (table_reference
+        (identifier))
+      (list
+        (column
+          (identifier)))
+      (keyword_values)
+      (list
+        (literal))
+      (list
+        (literal)))))
+
+================================================================================
+Insert with field name
+================================================================================
+
+INSERT INTO some_table
+  SET field = "String does not get highlight in INSERT SET syntax";
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (insert
+      (keyword_insert)
+      (keyword_into)
+      (table_reference
+        name: (identifier))
+      (keyword_set)
+      (assignment
+        left: (field
+          name: (identifier))
+        right: (literal)))))

--- a/test/corpus/transaction.txt
+++ b/test/corpus/transaction.txt
@@ -43,8 +43,9 @@ COMMIT;
   (statement
    (update
     (keyword_update)
-    (table_reference
-     name: (identifier))
+    (relation
+     (table_reference
+      name: (identifier)))
     (keyword_set)
     (assignment
       left: (field

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -11,8 +11,9 @@ SET for = foo + 1;
   (statement
     (update
       (keyword_update)
-      (table_reference
-        name: (identifier))
+      (relation
+        (table_reference
+          name: (identifier)))
       (keyword_set)
       (assignment
         left: (field
@@ -36,8 +37,9 @@ SET for = foo + 1;
     (update
       (keyword_update)
       (keyword_only)
-      (table_reference
-        name: (identifier))
+      (relation
+        (table_reference
+          name: (identifier)))
       (keyword_set)
       (assignment
         left: (field
@@ -60,8 +62,9 @@ SET for = foo + 1, col2 = col1;
   (statement
     (update
       (keyword_update)
-      (table_reference
-        name: (identifier))
+      (relation
+        (table_reference
+          name: (identifier)))
       (keyword_set)
       (assignment
         left: (field
@@ -90,10 +93,12 @@ WHERE items.id=month.item_id;
   (statement
     (update
       (keyword_update)
-      (table_reference
-        name: (identifier))
-      (table_reference
-        name: (identifier))
+      (relation
+        (table_reference
+          name: (identifier)))
+      (relation
+        (table_reference
+          name: (identifier)))
       (keyword_set)
       (assignment
         left: (field
@@ -125,11 +130,69 @@ SET ts = now();
   (statement
     (update
       (keyword_update)
-      (table_reference
-        name: (identifier))
+      (relation
+        (table_reference
+          name: (identifier)))
       (keyword_set)
       (assignment
         left: (field
           name: (identifier))
         right: (invocation
           name: (identifier))))))
+
+================================================================================
+Update with a JOIN
+================================================================================
+
+UPDATE table_a a
+INNER JOIN table_b b ON b.a = a.uid
+INNER JOIN table_c c ON c.b = b.uid
+SET
+a.d = 5;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (update
+      (keyword_update)
+      (relation
+        (table_reference
+          (identifier))
+        (identifier))
+      (join
+        (keyword_inner)
+        (keyword_join)
+        (relation
+          (table_reference
+            (identifier))
+          (identifier))
+        (keyword_on)
+        (binary_expression
+          (field
+            (identifier)
+            (identifier))
+          (field
+            (identifier)
+            (identifier))))
+      (join
+        (keyword_inner)
+        (keyword_join)
+        (relation
+          (table_reference
+            (identifier))
+          (identifier))
+        (keyword_on)
+        (binary_expression
+          (field
+            (identifier)
+            (identifier))
+          (field
+            (identifier)
+            (identifier))))
+      (keyword_set)
+      (assignment
+        (field
+          (identifier)
+          (identifier))
+        (literal)))))

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -196,3 +196,94 @@ a.d = 5;
           (identifier)
           (identifier))
         (literal)))))
+
+================================================================================
+Postgres style update
+================================================================================
+
+UPDATE table_a as a
+SET d = 5
+WHERE b.a = a.uid;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (update
+      (keyword_update)
+      (relation
+        (table_reference
+          (identifier))
+        (keyword_as)
+        (identifier))
+      (keyword_set)
+      (assignment
+        (field
+          (identifier))
+        (literal))
+      (where
+        (keyword_where)
+        (binary_expression
+          (field
+            (identifier)
+            (identifier))
+          (field
+            (identifier)
+            (identifier)))))))
+
+================================================================================
+Postgres style update w/ join
+================================================================================
+
+UPDATE table_a as a
+SET d = 5
+FROM table_b b
+INNER JOIN table_c c ON c.b = b.uid
+WHERE b.a = a.uid;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (update
+      (keyword_update)
+      (relation
+        (table_reference
+          (identifier))
+        (keyword_as)
+        (identifier))
+      (keyword_set)
+      (assignment
+        (field
+          (identifier))
+        (literal))
+      (from
+        (keyword_from)
+        (relation
+          (table_reference
+            (identifier))
+          (identifier))
+        (join
+          (keyword_inner)
+          (keyword_join)
+          (relation
+            (table_reference
+              (identifier))
+            (identifier))
+          (keyword_on)
+          (binary_expression
+            (field
+              (identifier)
+              (identifier))
+            (field
+              (identifier)
+              (identifier))))
+        (where
+          (keyword_where)
+          (binary_expression
+            (field
+              (identifier)
+              (identifier))
+            (field
+              (identifier)
+              (identifier))))))))


### PR DESCRIPTION
## What

There are 3 updates that fix the issues described in https://github.com/DerekStride/tree-sitter-sql/issues/67.

cc// @LeoniePhiline

### Update insert to support SET syntax

https://github.com/DerekStride/tree-sitter-sql/pull/68/commits/3f08080faf4902ce2f528c4ae699fb42169131ae
https://github.com/DerekStride/tree-sitter-sql/pull/68/commits/2fdc42869aafb9d00d28ccaee6be8b10c0386f1b

Also updates the values branch of the grammar to allow for specifying multiple lists of items. The other commit includes support for the postgres style update statement.

### Rework special cases for aggregate functions

https://github.com/DerekStride/tree-sitter-sql/pull/68/commits/8c0ca86319fe745eebfe7d8ebdf6ac43100517ba
https://github.com/DerekStride/tree-sitter-sql/pull/68/commits/61c6e23337ed72464dc5c614fc47f876c1ad6ad6

Previous to this commit `count` was a special case node. It worked a lot like the `invocation` node but had some custom grammar rules.

This commit introduced another special case node, group_concat. According to the [MySQL reference](https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html) there might not be many more like this but to provide a pattern for the future I moved both count & group_concat into a special anonymous node called `_aggregate_functions`.

The other commit adds the `_aggregate_expression` node from the suggestions.

### Consolidate UPDATE rules into 1 node

https://github.com/DerekStride/tree-sitter-sql/pull/68/commits/3b82416d4e4b10648cd79e2967b69e4f64480119

Previously there was separate anonymous nodes for single table & multi table update statements. This commit merges them into a single node and reworks them to support the JOIN syntax.