### PR TITLE
Parse more functionality of the `CREATE TABLE` statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -524,8 +524,12 @@ module.exports = grammar({
       $.keyword_table,
       optional($._if_not_exists),
       $.table_reference,
-      $.column_definitions,
+      optional($.column_definitions),
       optional($.table_options),
+      optional(seq(
+          $.keyword_as,
+          $._select_statement,
+      )),
     ),
 
     create_view: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -527,15 +527,21 @@ module.exports = grammar({
       $.table_reference,
       choice(
           seq(
-              optional($.column_definitions),
+              $.column_definitions,
               optional($.table_options),
+              optional(
+                  seq(
+                      $.keyword_as,
+                      $._select_statement,
+                  ),
+              )
           ),
           seq(
               optional($.table_options),
-              optional(seq(
+              seq(
                   $.keyword_as,
                   $._select_statement,
-              )),
+              ),
           ),
       )
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -865,14 +865,6 @@ module.exports = grammar({
         '=',
         field('value', $.identifier),
       ),
-      seq(
-          $.keyword_on,
-          $.keyword_commit,
-          choice(
-              $.keyword_drop,
-              seq($.keyword_delete, $.keyword_rows),
-              seq($.keyword_preserve, $.keyword_rows)
-          )),
     ),
 
     column_definitions: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -115,6 +115,7 @@ module.exports = grammar({
     keyword_owner: _ => make_keyword("owner"),
     keyword_temp: _ => make_keyword("temp"),
     keyword_temporary: _ => make_keyword("temporary"),
+    keyword_unlogged: _ => make_keyword("unlogged"),
     keyword_union: _ => make_keyword("union"),
     keyword_all: _ => make_keyword("all"),
     keyword_except: _ => make_keyword("except"),
@@ -514,7 +515,12 @@ module.exports = grammar({
 
     create_table: $ => seq(
       $.keyword_create,
-      optional($._temporary),
+      optional(
+          choice(
+              $._temporary,
+              $.keyword_unlogged
+          )
+      ),
       $.keyword_table,
       optional($._if_not_exists),
       $.table_reference,

--- a/grammar.js
+++ b/grammar.js
@@ -153,6 +153,7 @@ module.exports = grammar({
     keyword_brin: _ => make_keyword("brin"),
     keyword_like: _ => choice(make_keyword("like"),make_keyword("ilike")),
     keyword_similar: _ => make_keyword("similar"),
+    keyword_preserve: _ => make_keyword("preserve"),
 
     // Operators
     is_not: $ => prec.left(seq($.keyword_is, $.keyword_not)),
@@ -851,6 +852,14 @@ module.exports = grammar({
         '=',
         field('value', $.identifier),
       ),
+      seq(
+          $.keyword_on,
+          $.keyword_commit,
+          choice(
+              $.keyword_drop,
+              seq($.keyword_delete, $.keyword_rows),
+              seq($.keyword_preserve, $.keyword_rows)
+          )),
     ),
 
     column_definitions: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -525,12 +525,19 @@ module.exports = grammar({
       $.keyword_table,
       optional($._if_not_exists),
       $.table_reference,
-      optional($.column_definitions),
-      optional($.table_options),
-      optional(seq(
-          $.keyword_as,
-          $._select_statement,
-      )),
+      choice(
+          seq(
+              optional($.column_definitions),
+              optional($.table_options),
+          ),
+          seq(
+              optional($.table_options),
+              optional(seq(
+                  $.keyword_as,
+                  $._select_statement,
+              )),
+          ),
+      )
     ),
 
     create_view: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3877,54 +3877,6 @@
               }
             }
           ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "keyword_on"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "keyword_commit"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "keyword_drop"
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "keyword_delete"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "keyword_rows"
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "keyword_preserve"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "keyword_rows"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2440,34 +2440,9 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "column_definitions"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "column_definitions"
                 },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "table_options"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
                 {
                   "type": "CHOICE",
                   "members": [
@@ -2498,6 +2473,36 @@
                     },
                     {
                       "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "table_options"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_as"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_select_statement"
                     }
                   ]
                 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -334,6 +334,10 @@
       "type": "PATTERN",
       "value": "temporary|TEMPORARY"
     },
+    "keyword_unlogged": {
+      "type": "PATTERN",
+      "value": "unlogged|UNLOGGED"
+    },
     "keyword_union": {
       "type": "PATTERN",
       "value": "union|UNION"
@@ -490,6 +494,30 @@
     "keyword_similar": {
       "type": "PATTERN",
       "value": "similar|SIMILAR"
+    },
+    "keyword_stored": {
+      "type": "PATTERN",
+      "value": "stored|STORED"
+    },
+    "keyword_parquet": {
+      "type": "PATTERN",
+      "value": "parquet|PARQUET"
+    },
+    "keyword_csv": {
+      "type": "PATTERN",
+      "value": "csv|CSV"
+    },
+    "keyword_compute": {
+      "type": "PATTERN",
+      "value": "compute|COMPUTE"
+    },
+    "keyword_statistics": {
+      "type": "PATTERN",
+      "value": "statistics|STATISTICS"
+    },
+    "keyword_external": {
+      "type": "PATTERN",
+      "value": "external|EXTERNAL"
     },
     "is_not": {
       "type": "PREC_LEFT",
@@ -2377,6 +2405,32 @@
         }
       ]
     },
+    "store_options": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_stored"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_as"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_parquet"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_csv"
+            }
+          ]
+        }
+      ]
+    },
     "create_table": {
       "type": "SEQ",
       "members": [
@@ -2388,8 +2442,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_temporary"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_temporary"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_unlogged"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -2417,8 +2480,16 @@
           "name": "table_reference"
         },
         {
-          "type": "SYMBOL",
-          "name": "column_definitions"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "column_definitions"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -2426,6 +2497,39 @@
             {
               "type": "SYMBOL",
               "name": "table_options"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "store_options"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_as"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_select_statement"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -7095,4 +7199,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -495,29 +495,9 @@
       "type": "PATTERN",
       "value": "similar|SIMILAR"
     },
-    "keyword_stored": {
+    "keyword_preserve": {
       "type": "PATTERN",
-      "value": "stored|STORED"
-    },
-    "keyword_parquet": {
-      "type": "PATTERN",
-      "value": "parquet|PARQUET"
-    },
-    "keyword_csv": {
-      "type": "PATTERN",
-      "value": "csv|CSV"
-    },
-    "keyword_compute": {
-      "type": "PATTERN",
-      "value": "compute|COMPUTE"
-    },
-    "keyword_statistics": {
-      "type": "PATTERN",
-      "value": "statistics|STATISTICS"
-    },
-    "keyword_external": {
-      "type": "PATTERN",
-      "value": "external|EXTERNAL"
+      "value": "preserve|PRESERVE"
     },
     "is_not": {
       "type": "PREC_LEFT",
@@ -2405,32 +2385,6 @@
         }
       ]
     },
-    "store_options": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "keyword_stored"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "keyword_as"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "keyword_parquet"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "keyword_csv"
-            }
-          ]
-        }
-      ]
-    },
     "create_table": {
       "type": "SEQ",
       "members": [
@@ -2497,18 +2451,6 @@
             {
               "type": "SYMBOL",
               "name": "table_options"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "store_options"
             },
             {
               "type": "BLANK"
@@ -3901,6 +3843,54 @@
                 "type": "SYMBOL",
                 "name": "identifier"
               }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_on"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_commit"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_drop"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_delete"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_rows"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_preserve"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_rows"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2437,44 +2437,71 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "column_definitions"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "table_options"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "keyword_as"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "column_definitions"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_select_statement"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "table_options"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
             {
-              "type": "BLANK"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "table_options"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "keyword_as"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_select_statement"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -495,9 +495,29 @@
       "type": "PATTERN",
       "value": "similar|SIMILAR"
     },
-    "keyword_preserve": {
+    "keyword_stored": {
       "type": "PATTERN",
-      "value": "preserve|PRESERVE"
+      "value": "stored|STORED"
+    },
+    "keyword_parquet": {
+      "type": "PATTERN",
+      "value": "parquet|PARQUET"
+    },
+    "keyword_csv": {
+      "type": "PATTERN",
+      "value": "csv|CSV"
+    },
+    "keyword_compute": {
+      "type": "PATTERN",
+      "value": "compute|COMPUTE"
+    },
+    "keyword_statistics": {
+      "type": "PATTERN",
+      "value": "statistics|STATISTICS"
+    },
+    "keyword_external": {
+      "type": "PATTERN",
+      "value": "external|EXTERNAL"
     },
     "is_not": {
       "type": "PREC_LEFT",
@@ -2385,6 +2405,32 @@
         }
       ]
     },
+    "store_options": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_stored"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_as"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_parquet"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_csv"
+            }
+          ]
+        }
+      ]
+    },
     "create_table": {
       "type": "SEQ",
       "members": [
@@ -2437,76 +2483,56 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "column_definitions"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "table_options"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "keyword_as"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "_select_statement"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "column_definitions"
             },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "table_options"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "store_options"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
             {
               "type": "SEQ",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "table_options"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "keyword_as"
                 },
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "keyword_as"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_select_statement"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_select_statement"
                 }
               ]
+            },
+            {
+              "type": "BLANK"
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -495,29 +495,9 @@
       "type": "PATTERN",
       "value": "similar|SIMILAR"
     },
-    "keyword_stored": {
+    "keyword_preserve": {
       "type": "PATTERN",
-      "value": "stored|STORED"
-    },
-    "keyword_parquet": {
-      "type": "PATTERN",
-      "value": "parquet|PARQUET"
-    },
-    "keyword_csv": {
-      "type": "PATTERN",
-      "value": "csv|CSV"
-    },
-    "keyword_compute": {
-      "type": "PATTERN",
-      "value": "compute|COMPUTE"
-    },
-    "keyword_statistics": {
-      "type": "PATTERN",
-      "value": "statistics|STATISTICS"
-    },
-    "keyword_external": {
-      "type": "PATTERN",
-      "value": "external|EXTERNAL"
+      "value": "preserve|PRESERVE"
     },
     "is_not": {
       "type": "PREC_LEFT",
@@ -2405,32 +2385,6 @@
         }
       ]
     },
-    "store_options": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "keyword_stored"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "keyword_as"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "keyword_parquet"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "keyword_csv"
-            }
-          ]
-        }
-      ]
-    },
     "create_table": {
       "type": "SEQ",
       "members": [
@@ -2483,56 +2437,76 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "column_definitions"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "table_options"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "store_options"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
               "type": "SEQ",
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "keyword_as"
+                  "name": "column_definitions"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_select_statement"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "table_options"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "keyword_as"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_select_statement"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },
             {
-              "type": "BLANK"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "table_options"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_as"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_select_statement"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1954,6 +1954,10 @@
           "named": true
         },
         {
+          "type": "store_options",
+          "named": true
+        },
+        {
           "type": "table_options",
           "named": true
         },
@@ -3924,6 +3928,33 @@
     }
   },
   {
+    "type": "store_options",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_as",
+          "named": true
+        },
+        {
+          "type": "keyword_csv",
+          "named": true
+        },
+        {
+          "type": "keyword_parquet",
+          "named": true
+        },
+        {
+          "type": "keyword_stored",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "subquery",
     "named": true,
     "fields": {},
@@ -4729,6 +4760,10 @@
     "named": true
   },
   {
+    "type": "keyword_csv",
+    "named": true
+  },
+  {
     "type": "keyword_current",
     "named": true
   },
@@ -4993,6 +5028,10 @@
     "named": true
   },
   {
+    "type": "keyword_parquet",
+    "named": true
+  },
+  {
     "type": "keyword_partition",
     "named": true
   },
@@ -5074,6 +5113,10 @@
   },
   {
     "type": "keyword_spgist",
+    "named": true
+  },
+  {
+    "type": "keyword_stored",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3948,7 +3948,7 @@
     "fields": {
       "name": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
           {
             "type": "identifier",
@@ -3966,36 +3966,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "keyword_commit",
-          "named": true
-        },
-        {
-          "type": "keyword_delete",
-          "named": true
-        },
-        {
-          "type": "keyword_drop",
-          "named": true
-        },
-        {
-          "type": "keyword_on",
-          "named": true
-        },
-        {
-          "type": "keyword_preserve",
-          "named": true
-        },
-        {
-          "type": "keyword_rows",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -5028,10 +4998,6 @@
   },
   {
     "type": "keyword_preceding",
-    "named": true
-  },
-  {
-    "type": "keyword_preserve",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1954,10 +1954,6 @@
           "named": true
         },
         {
-          "type": "store_options",
-          "named": true
-        },
-        {
           "type": "table_options",
           "named": true
         },
@@ -3928,33 +3924,6 @@
     }
   },
   {
-    "type": "store_options",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "keyword_as",
-          "named": true
-        },
-        {
-          "type": "keyword_csv",
-          "named": true
-        },
-        {
-          "type": "keyword_parquet",
-          "named": true
-        },
-        {
-          "type": "keyword_stored",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "subquery",
     "named": true,
     "fields": {},
@@ -3979,7 +3948,7 @@
     "fields": {
       "name": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "identifier",
@@ -3997,6 +3966,36 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "keyword_commit",
+          "named": true
+        },
+        {
+          "type": "keyword_delete",
+          "named": true
+        },
+        {
+          "type": "keyword_drop",
+          "named": true
+        },
+        {
+          "type": "keyword_on",
+          "named": true
+        },
+        {
+          "type": "keyword_preserve",
+          "named": true
+        },
+        {
+          "type": "keyword_rows",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -4760,10 +4759,6 @@
     "named": true
   },
   {
-    "type": "keyword_csv",
-    "named": true
-  },
-  {
     "type": "keyword_current",
     "named": true
   },
@@ -5028,15 +5023,15 @@
     "named": true
   },
   {
-    "type": "keyword_parquet",
-    "named": true
-  },
-  {
     "type": "keyword_partition",
     "named": true
   },
   {
     "type": "keyword_preceding",
+    "named": true
+  },
+  {
+    "type": "keyword_preserve",
     "named": true
   },
   {
@@ -5113,10 +5108,6 @@
   },
   {
     "type": "keyword_spgist",
-    "named": true
-  },
-  {
-    "type": "keyword_stored",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1894,7 +1894,23 @@
           "named": true
         },
         {
+          "type": "from",
+          "named": true
+        },
+        {
+          "type": "keyword_all",
+          "named": true
+        },
+        {
+          "type": "keyword_as",
+          "named": true
+        },
+        {
           "type": "keyword_create",
+          "named": true
+        },
+        {
+          "type": "keyword_except",
           "named": true
         },
         {
@@ -1903,6 +1919,10 @@
         },
         {
           "type": "keyword_if",
+          "named": true
+        },
+        {
+          "type": "keyword_intersect",
           "named": true
         },
         {
@@ -1919,6 +1939,22 @@
         },
         {
           "type": "keyword_temporary",
+          "named": true
+        },
+        {
+          "type": "keyword_union",
+          "named": true
+        },
+        {
+          "type": "keyword_unlogged",
+          "named": true
+        },
+        {
+          "type": "select",
+          "named": true
+        },
+        {
+          "type": "store_options",
           "named": true
         },
         {
@@ -3892,6 +3928,33 @@
     }
   },
   {
+    "type": "store_options",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_as",
+          "named": true
+        },
+        {
+          "type": "keyword_csv",
+          "named": true
+        },
+        {
+          "type": "keyword_parquet",
+          "named": true
+        },
+        {
+          "type": "keyword_stored",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "subquery",
     "named": true,
     "fields": {},
@@ -4697,6 +4760,10 @@
     "named": true
   },
   {
+    "type": "keyword_csv",
+    "named": true
+  },
+  {
     "type": "keyword_current",
     "named": true
   },
@@ -4961,6 +5028,10 @@
     "named": true
   },
   {
+    "type": "keyword_parquet",
+    "named": true
+  },
+  {
     "type": "keyword_partition",
     "named": true
   },
@@ -5045,6 +5116,10 @@
     "named": true
   },
   {
+    "type": "keyword_stored",
+    "named": true
+  },
+  {
     "type": "keyword_table",
     "named": true
   },
@@ -5094,6 +5169,10 @@
   },
   {
     "type": "keyword_unique",
+    "named": true
+  },
+  {
+    "type": "keyword_unlogged",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1954,10 +1954,6 @@
           "named": true
         },
         {
-          "type": "store_options",
-          "named": true
-        },
-        {
           "type": "table_options",
           "named": true
         },
@@ -3928,33 +3924,6 @@
     }
   },
   {
-    "type": "store_options",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "keyword_as",
-          "named": true
-        },
-        {
-          "type": "keyword_csv",
-          "named": true
-        },
-        {
-          "type": "keyword_parquet",
-          "named": true
-        },
-        {
-          "type": "keyword_stored",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "subquery",
     "named": true,
     "fields": {},
@@ -4760,10 +4729,6 @@
     "named": true
   },
   {
-    "type": "keyword_csv",
-    "named": true
-  },
-  {
     "type": "keyword_current",
     "named": true
   },
@@ -5028,10 +4993,6 @@
     "named": true
   },
   {
-    "type": "keyword_parquet",
-    "named": true
-  },
-  {
     "type": "keyword_partition",
     "named": true
   },
@@ -5113,10 +5074,6 @@
   },
   {
     "type": "keyword_spgist",
-    "named": true
-  },
-  {
-    "type": "keyword_stored",
     "named": true
   },
   {

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -82,33 +82,6 @@ CREATE TEMP TABLE my_table (id BIGINT NOT NULL PRIMARY KEY);
       (keyword_primary)
       (keyword_key))))))
 
-==================
-Create temp table with commit behaviour
-==================
-
-CREATE TEMP TABLE my_table (id BIGINT)
-ON COMMIT PRESERVE ROWS;
-
----
-
-(program
- (statement
-  (create_table
-   (keyword_create)
-   (keyword_temp)
-   (keyword_table)
-   (table_reference
-    name: (identifier))
-   (column_definitions
-    (column_definition
-      name: (identifier)
-      type: (bigint (keyword_bigint))))
-   (table_options
-     (table_option
-       (keyword_on)
-       (keyword_commit)
-       (keyword_preserve)
-       (keyword_rows))))))
 
 ==================
 Create table with constraint

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -83,6 +83,34 @@ CREATE TEMP TABLE my_table (id BIGINT NOT NULL PRIMARY KEY);
       (keyword_key))))))
 
 ==================
+Create temp table with commit behaviour
+==================
+
+CREATE TEMP TABLE my_table (id BIGINT)
+ON COMMIT PRESERVE ROWS;
+
+---
+
+(program
+ (statement
+  (create_table
+   (keyword_create)
+   (keyword_temp)
+   (keyword_table)
+   (table_reference
+    name: (identifier))
+   (column_definitions
+    (column_definition
+      name: (identifier)
+      type: (bigint (keyword_bigint))))
+   (table_options
+     (table_option
+       (keyword_on)
+       (keyword_commit)
+       (keyword_preserve)
+       (keyword_rows))))))
+
+==================
 Create table with constraint
 ==================
 

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -683,3 +683,28 @@ CREATE TABLE tableName (
           (varchar
             (keyword_varchar))
           (keyword_null))))))
+
+==================
+Create unlogged table
+==================
+
+CREATE UNLOGGED TABLE tableName (
+    id NUMERIC
+);
+
+---
+
+(program
+  (statement
+    (create_table
+      (keyword_create)
+      (keyword_unlogged)
+      (keyword_table)
+      (table_reference
+        (identifier))
+      (column_definitions
+        (column_definition
+          (identifier)
+          (numeric
+            (keyword_numeric))
+          )))))

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -708,3 +708,31 @@ CREATE UNLOGGED TABLE tableName (
           (numeric
             (keyword_numeric))
           )))))
+
+
+==================
+Create table as select
+==================
+
+CREATE TABLE tableName AS SELECT * FROM otherTable;
+
+---
+
+(program
+  (statement
+    (create_table
+      (keyword_create)
+      (keyword_table)
+      (table_reference
+        name: (identifier))
+      (keyword_as)
+      (select
+        (keyword_select)
+        (select_expression
+          (all_fields)))
+        (from
+          (keyword_from)
+          (relation
+            (table_reference
+              name: (identifier))
+          )))))


### PR DESCRIPTION
I noticed that currently, we cannot parse a statement like:

```sql
CREATE TABLE tab1 AS SELECT * FROM tab2
```
This is now possible. I also added the `ON COMMIT` behavior for temp tables and the `UNLOGGED` options.

Reference: https://www.postgresql.org/docs/15/sql-createtableas.html