### PR TITLE
Default values in Column Definitions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -868,7 +868,13 @@ module.exports = grammar({
     ),
     _inner_default_expression: $ => choice(
         $.literal,
+        $.list,
+        $.cast,
+        $.binary_expression,
+        $.unary_expression,
+        $.array,
         $.invocation,
+        alias($.implicit_cast, $.cast),
     ),
 
     column_definition: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -853,7 +853,22 @@ module.exports = grammar({
       ')',
     ),
 
+    column_definition: $ => seq(
+      field('name', $.identifier),
+      field('type', $._type),
+      repeat($._column_constraint),
+    ),
 
+    _column_constraint: $ => choice(
+        choice(
+            $.keyword_null,
+            $._not_null,
+        ),
+        $._default_expression,
+        $._primary_key,
+        $.keyword_auto_increment,
+        $.direction,
+    ),
 
     _default_expression: $ => seq(
         $.keyword_default,
@@ -875,19 +890,6 @@ module.exports = grammar({
         $.array,
         $.invocation,
         alias($.implicit_cast, $.cast),
-    ),
-
-    column_definition: $ => seq(
-      field('name', $.identifier),
-      field('type', $._type),
-      optional($._default_expression),
-      choice(
-        optional($.keyword_null),
-        optional($._not_null),
-      ),
-      optional($.keyword_auto_increment),
-      optional($._primary_key),
-      optional($.direction),
     ),
 
     constraints: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -853,13 +853,31 @@ module.exports = grammar({
       ')',
     ),
 
+
+
+    _default_expression: $ => seq(
+        $.keyword_default,
+            choice(
+            seq(
+                '(',
+                    $._inner_default_expression,
+                ')',
+            ),
+            $._inner_default_expression,
+        )
+    ),
+    _inner_default_expression: $ => choice(
+        $.literal,
+        $.invocation,
+    ),
+
     column_definition: $ => seq(
       field('name', $.identifier),
       field('type', $._type),
+      optional($._default_expression),
       choice(
         optional($.keyword_null),
         optional($._not_null),
-        optional($._default_null),
       ),
       optional($.keyword_auto_increment),
       optional($._primary_key),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3891,7 +3891,36 @@
         },
         {
           "type": "SYMBOL",
+          "name": "list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cast"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "binary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array"
+        },
+        {
+          "type": "SYMBOL",
           "name": "invocation"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "implicit_cast"
+          },
+          "named": true,
+          "value": "cast"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3847,6 +3847,68 @@
         }
       ]
     },
+    "column_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_type"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_column_constraint"
+          }
+        }
+      ]
+    },
+    "_column_constraint": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_null"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_not_null"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_default_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_primary_key"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_auto_increment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "direction"
+        }
+      ]
+    },
     "_default_expression": {
       "type": "SEQ",
       "members": [
@@ -3921,104 +3983,6 @@
           },
           "named": true,
           "value": "cast"
-        }
-      ]
-    },
-    "column_definition": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "type",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_type"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_default_expression"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "keyword_null"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_not_null"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "keyword_auto_increment"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_primary_key"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "direction"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3847,6 +3847,54 @@
         }
       ]
     },
+    "_default_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_default"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_inner_default_expression"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_inner_default_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "_inner_default_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "invocation"
+        }
+      ]
+    },
     "column_definition": {
       "type": "SEQ",
       "members": [
@@ -3870,6 +3918,18 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "SYMBOL",
+              "name": "_default_expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "CHOICE",
               "members": [
                 {
@@ -3887,18 +3947,6 @@
                 {
                   "type": "SYMBOL",
                   "name": "_not_null"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_default_null"
                 },
                 {
                   "type": "BLANK"
@@ -7042,4 +7090,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1449,6 +1449,18 @@
       "required": false,
       "types": [
         {
+          "type": "array",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
           "type": "direction",
           "named": true
         },
@@ -1481,7 +1493,15 @@
           "named": true
         },
         {
+          "type": "list",
+          "named": true
+        },
+        {
           "type": "literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1453,6 +1453,10 @@
           "named": true
         },
         {
+          "type": "invocation",
+          "named": true
+        },
+        {
           "type": "keyword_auto_increment",
           "named": true
         },
@@ -1474,6 +1478,10 @@
         },
         {
           "type": "keyword_primary",
+          "named": true
+        },
+        {
+          "type": "literal",
           "named": true
         }
       ]

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -53,7 +53,8 @@ CREATE TABLE my_table (
       name: (identifier)
       type: (keyword_date)
       (keyword_default)
-      (keyword_null)
+      (literal
+        (keyword_null))
       (direction (keyword_asc)))))))
 
 ==================
@@ -135,6 +136,8 @@ Create table with constraint on multiple columns
 CREATE TABLE my_table (
   host CHAR(50) NOT NULL,
   created_date DATE NOT NULL,
+  random FLOAT DEFAULT RAND(),
+  random TEXT DEFAULT 'test',
   KEY `idx` (`host`, `created_date`)
 );
 
@@ -161,6 +164,18 @@ CREATE TABLE my_table (
      type: (keyword_date)
      (keyword_not)
      (keyword_null))
+    (column_definition
+      name: (identifier)
+      type: (float
+        (keyword_float))
+      (keyword_default)
+      (invocation
+        name: (identifier)))
+    (column_definition
+      name: (identifier)
+      type: (keyword_text)
+      (keyword_default)
+      (literal))
     (constraints
      (constraint
       (keyword_key)
@@ -292,7 +307,8 @@ CREATE TABLE IF NOT EXISTS `addresses` (
         (keyword_bigint)
         size: (literal))
       (keyword_default)
-      (keyword_null))
+      (literal
+        (keyword_null)))
     (column_definition
       name: (identifier)
       type:
@@ -300,12 +316,14 @@ CREATE TABLE IF NOT EXISTS `addresses` (
         (keyword_varchar)
         size: (literal))
       (keyword_default)
-      (keyword_null))
+      (literal
+        (keyword_null)))
     (column_definition
       name: (identifier)
       type: (keyword_datetime)
       (keyword_default)
-      (keyword_null))
+      (literal
+        (keyword_null)))
     (constraints
      (constraint
       (keyword_primary)
@@ -373,7 +391,8 @@ CREATE TABLE IF NOT EXISTS `addresses` (
         (keyword_bigint)
         size: (literal))
       (keyword_default)
-      (keyword_null))
+      (literal
+        (keyword_null)))
     (column_definition
       name: (identifier)
       type:
@@ -381,7 +400,8 @@ CREATE TABLE IF NOT EXISTS `addresses` (
         (keyword_varchar)
         size: (literal))
       (keyword_default)
-      (keyword_null))))))
+      (literal
+        (keyword_null)))))))
 
 ==================
 Create table with table options
@@ -414,7 +434,8 @@ CREATE TABLE my_table (
       name: (identifier)
       type: (keyword_date)
       (keyword_default)
-      (keyword_null)
+      (literal
+        (keyword_null))
       (direction (keyword_asc))))
    (table_options
     (table_option


### PR DESCRIPTION
Fixes one problem reported in #71

Modified `column_definitions` to accept `DEFAULT` with `literal` or `invocation` optionally in parenthesis.

