### PR TITLE
feat: Optional `COLUMN` in `ALTER TABLE` for `ADD`, `CHANGE` and `DROP`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -660,7 +660,9 @@ module.exports = grammar({
 
     add_column: $ => seq(
       $.keyword_add,
-      $.keyword_column,
+      optional(
+        $.keyword_column,
+      ),
       optional($._if_not_exists),
       $.column_definition,
     ),
@@ -668,7 +670,9 @@ module.exports = grammar({
     alter_column: $ => seq(
       // TODO constraint management
       $.keyword_alter,
-      $.keyword_column,
+      optional(
+        $.keyword_column,
+      ),
       field('name', $.identifier),
       choice(
         seq(
@@ -703,7 +707,9 @@ module.exports = grammar({
 
     drop_column: $ => seq(
       $.keyword_drop,
-      $.keyword_column,
+      optional(
+        $.keyword_column,
+      ),
       optional($._if_exists),
       field('name', $.identifier),
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2953,8 +2953,16 @@
           "name": "keyword_add"
         },
         {
-          "type": "SYMBOL",
-          "name": "keyword_column"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_column"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -2982,8 +2990,16 @@
           "name": "keyword_alter"
         },
         {
-          "type": "SYMBOL",
-          "name": "keyword_column"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_column"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -3102,8 +3118,16 @@
           "name": "keyword_drop"
         },
         {
-          "type": "SYMBOL",
-          "name": "keyword_column"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_column"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -13,7 +13,35 @@ ALTER TABLE my_table
    (keyword_alter)
    (keyword_table)
    (table_reference name: (identifier))
-   (add_column (keyword_add) (keyword_column)
+   (add_column
+    (keyword_add)
+    (keyword_column)
+    (column_definition
+     name: (identifier)
+     type: (varchar
+      (keyword_varchar)
+      size: (literal))
+     (keyword_not)
+     (keyword_null))
+   ))))
+
+==================
+Alter table and add column, eliding column keyword
+==================
+
+ALTER TABLE my_table
+  ADD val3 VARCHAR(100) NOT NULL;
+
+---
+
+(program
+ (statement
+  (alter_table
+   (keyword_alter)
+   (keyword_table)
+   (table_reference name: (identifier))
+   (add_column
+    (keyword_add)
     (column_definition
      name: (identifier)
      type: (varchar
@@ -94,6 +122,28 @@ ALTER TABLE my_table
   )))
 
 ==================
+Alter table and alter column changing type, eliding column keyword
+==================
+
+ALTER TABLE my_table
+  ALTER val3 TYPE VARCHAR(255);
+
+---
+
+(program
+ (statement
+  (alter_table
+   (keyword_alter)
+   (keyword_table)
+   (table_reference name: (identifier))
+   (alter_column
+    (keyword_alter)
+    name: (identifier)
+    (keyword_type)
+    type: (varchar (keyword_varchar) size: (literal)))
+  )))
+
+==================
 Alter table and alter column dropping not-null constraint
 ==================
 
@@ -137,6 +187,25 @@ ALTER TABLE my_table
     name: (identifier))
   )))
 
+==================
+Alter table and drop column, eliding column keyword
+==================
+
+ALTER TABLE my_table
+  DROP val3;
+
+---
+
+(program
+ (statement
+  (alter_table
+   (keyword_alter)
+   (keyword_table)
+   (table_reference name: (identifier))
+   (drop_column
+    (keyword_drop)
+    name: (identifier))
+  )))
 
 ==================
 Alter table and rename column


### PR DESCRIPTION
Fixes #78

# Before
![image](https://user-images.githubusercontent.com/22329650/216136376-1d1407cb-085b-43bd-9edc-3d98e86f5218.png)

# After
![image](https://user-images.githubusercontent.com/22329650/216136506-cfcd6310-8dfd-4bfe-a39f-87eed7ec7995.png)

# Noob check

I changed `grammar.js`, then ran `tree-sitter generate`. `src/` was updated. 
Did I do that correctly? I haven't worked with tree sitter grammars yet.

I also ran `tree-sitter build-wasm` and `tree-sitter playground` to verify the fix.