### PR TITLE
Add Hive statements

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -519,6 +519,110 @@
       "type": "PATTERN",
       "value": "zerofill|ZEROFILL"
     },
+    "keyword_external": {
+      "type": "PATTERN",
+      "value": "external|EXTERNAL"
+    },
+    "keyword_stored": {
+      "type": "PATTERN",
+      "value": "stored|STORED"
+    },
+    "keyword_cached": {
+      "type": "PATTERN",
+      "value": "cached|CACHED"
+    },
+    "keyword_uncached": {
+      "type": "PATTERN",
+      "value": "uncached|UNCACHED"
+    },
+    "keyword_replication": {
+      "type": "PATTERN",
+      "value": "replication|REPLICATION"
+    },
+    "keyword_tblproperties": {
+      "type": "PATTERN",
+      "value": "tblproperties|TBLPROPERTIES"
+    },
+    "keyword_compute": {
+      "type": "PATTERN",
+      "value": "compute|COMPUTE"
+    },
+    "keyword_stats": {
+      "type": "PATTERN",
+      "value": "stats|STATS"
+    },
+    "keyword_location": {
+      "type": "PATTERN",
+      "value": "location|LOCATION"
+    },
+    "keyword_partitioned": {
+      "type": "PATTERN",
+      "value": "partitioned|PARTITIONED"
+    },
+    "keyword_comment": {
+      "type": "PATTERN",
+      "value": "comment|COMMENT"
+    },
+    "keyword_sort": {
+      "type": "PATTERN",
+      "value": "sort|SORT"
+    },
+    "keyword_format": {
+      "type": "PATTERN",
+      "value": "format|FORMAT"
+    },
+    "keyword_delimited": {
+      "type": "PATTERN",
+      "value": "delimited|DELIMITED"
+    },
+    "keyword_fields": {
+      "type": "PATTERN",
+      "value": "fields|FIELDS"
+    },
+    "keyword_terminated": {
+      "type": "PATTERN",
+      "value": "terminated|TERMINATED"
+    },
+    "keyword_escaped": {
+      "type": "PATTERN",
+      "value": "escaped|ESCAPED"
+    },
+    "keyword_lines": {
+      "type": "PATTERN",
+      "value": "lines|LINES"
+    },
+    "keyword_parquet": {
+      "type": "PATTERN",
+      "value": "parquet|PARQUET"
+    },
+    "keyword_rcfile": {
+      "type": "PATTERN",
+      "value": "rcfile|RCFILE"
+    },
+    "keyword_csv": {
+      "type": "PATTERN",
+      "value": "csv|CSV"
+    },
+    "keyword_textfile": {
+      "type": "PATTERN",
+      "value": "textfile|TEXTFILE"
+    },
+    "keyword_avro": {
+      "type": "PATTERN",
+      "value": "avro|AVRO"
+    },
+    "keyword_sequencefile": {
+      "type": "PATTERN",
+      "value": "sequencefile|SEQUENCEFILE"
+    },
+    "keyword_orc": {
+      "type": "PATTERN",
+      "value": "orc|ORC"
+    },
+    "keyword_jsonfile": {
+      "type": "PATTERN",
+      "value": "jsonfile|JSONFILE"
+    },
     "is_not": {
       "type": "PREC_LEFT",
       "value": 0,
@@ -3773,6 +3877,31 @@
         }
       ]
     },
+    "_table_settings": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "table_partition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "stored_as"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "storage_location"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "table_sort"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "row_format"
+        }
+      ]
+    },
     "create_table": {
       "type": "SEQ",
       "members": [
@@ -3793,6 +3922,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "keyword_unlogged"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_external"
                 }
               ]
             },
@@ -3832,6 +3965,13 @@
                   "name": "column_definitions"
                 },
                 {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_table_settings"
+                  }
+                },
+                {
                   "type": "CHOICE",
                   "members": [
                     {
@@ -3869,6 +4009,13 @@
             {
               "type": "SEQ",
               "members": [
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_table_settings"
+                  }
+                },
                 {
                   "type": "CHOICE",
                   "members": [
@@ -5217,6 +5364,379 @@
         ]
       }
     },
+    "storage_location": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "keyword_location"
+          },
+          {
+            "type": "FIELD",
+            "name": "path",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_literal_string"
+              },
+              "named": true,
+              "value": "identifier"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "keyword_cached"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "keyword_in"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "pool",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_literal_string"
+                      },
+                      "named": true,
+                      "value": "identifier"
+                    }
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "keyword_uncached"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "keyword_with"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "keyword_replication"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "="
+                              },
+                              {
+                                "type": "FIELD",
+                                "name": "value",
+                                "content": {
+                                  "type": "ALIAS",
+                                  "content": {
+                                    "type": "SYMBOL",
+                                    "name": "_number"
+                                  },
+                                  "named": true,
+                                  "value": "literal"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "row_format": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_row"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_format"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_delimited"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_fields"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_terminated"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_by"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_literal_string"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "keyword_escaped"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "keyword_by"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_literal_string"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_lines"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_terminated"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_by"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_literal_string"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "table_sort": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_sort"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_by"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "table_partition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_partition"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_by"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_range"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_hash"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_partitioned"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_by"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "column_definitions"
+            }
+          ]
+        }
+      ]
+    },
+    "stored_as": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_stored"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_as"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_parquet"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_csv"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_sequencefile"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_textfile"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_rcfile"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_orc"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_avro"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "keyword_jsonfile"
+            }
+          ]
+        }
+      ]
+    },
     "assignment": {
       "type": "SEQ",
       "members": [
@@ -5243,11 +5763,53 @@
       ]
     },
     "table_options": {
-      "type": "REPEAT1",
-      "content": {
-        "type": "SYMBOL",
-        "name": "table_option"
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_tblproperties"
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "table_option"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "table_option"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "table_option"
+          }
+        }
+      ]
     },
     "table_option": {
       "type": "CHOICE",
@@ -5310,6 +5872,10 @@
                   {
                     "type": "SYMBOL",
                     "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_literal_string"
                   }
                 ]
               }
@@ -5322,8 +5888,17 @@
               "type": "FIELD",
               "name": "value",
               "content": {
-                "type": "SYMBOL",
-                "name": "identifier"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_literal_string"
+                  }
+                ]
               }
             }
           ]
@@ -8632,4 +9207,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1942,6 +1942,10 @@
           "named": true
         },
         {
+          "type": "keyword_external",
+          "named": true
+        },
+        {
           "type": "keyword_if",
           "named": true
         },
@@ -1974,7 +1978,19 @@
           "named": true
         },
         {
+          "type": "row_format",
+          "named": true
+        },
+        {
           "type": "select",
+          "named": true
+        },
+        {
+          "type": "storage_location",
+          "named": true
+        },
+        {
+          "type": "stored_as",
           "named": true
         },
         {
@@ -1982,7 +1998,15 @@
           "named": true
         },
         {
+          "type": "table_partition",
+          "named": true
+        },
+        {
           "type": "table_reference",
+          "named": true
+        },
+        {
+          "type": "table_sort",
           "named": true
         }
       ]
@@ -3910,6 +3934,49 @@
     }
   },
   {
+    "type": "row_format",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_by",
+          "named": true
+        },
+        {
+          "type": "keyword_delimited",
+          "named": true
+        },
+        {
+          "type": "keyword_escaped",
+          "named": true
+        },
+        {
+          "type": "keyword_fields",
+          "named": true
+        },
+        {
+          "type": "keyword_format",
+          "named": true
+        },
+        {
+          "type": "keyword_lines",
+          "named": true
+        },
+        {
+          "type": "keyword_row",
+          "named": true
+        },
+        {
+          "type": "keyword_terminated",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "select",
     "named": true,
     "fields": {},
@@ -4130,6 +4197,123 @@
     }
   },
   {
+    "type": "storage_location",
+    "named": true,
+    "fields": {
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "pool": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "literal",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_cached",
+          "named": true
+        },
+        {
+          "type": "keyword_in",
+          "named": true
+        },
+        {
+          "type": "keyword_location",
+          "named": true
+        },
+        {
+          "type": "keyword_replication",
+          "named": true
+        },
+        {
+          "type": "keyword_uncached",
+          "named": true
+        },
+        {
+          "type": "keyword_with",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "stored_as",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_as",
+          "named": true
+        },
+        {
+          "type": "keyword_avro",
+          "named": true
+        },
+        {
+          "type": "keyword_csv",
+          "named": true
+        },
+        {
+          "type": "keyword_jsonfile",
+          "named": true
+        },
+        {
+          "type": "keyword_orc",
+          "named": true
+        },
+        {
+          "type": "keyword_parquet",
+          "named": true
+        },
+        {
+          "type": "keyword_rcfile",
+          "named": true
+        },
+        {
+          "type": "keyword_sequencefile",
+          "named": true
+        },
+        {
+          "type": "keyword_stored",
+          "named": true
+        },
+        {
+          "type": "keyword_textfile",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "subquery",
     "named": true,
     "fields": {},
@@ -4153,9 +4337,17 @@
     "named": true,
     "fields": {
       "name": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
+          {
+            "type": "\"",
+            "named": false
+          },
+          {
+            "type": "'",
+            "named": false
+          },
           {
             "type": "identifier",
             "named": true
@@ -4171,9 +4363,17 @@
         ]
       },
       "value": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
+          {
+            "type": "\"",
+            "named": false
+          },
+          {
+            "type": "'",
+            "named": false
+          },
           {
             "type": "identifier",
             "named": true
@@ -4217,7 +4417,50 @@
       "required": true,
       "types": [
         {
+          "type": "keyword_tblproperties",
+          "named": true
+        },
+        {
           "type": "table_option",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "table_partition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "column_definitions",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "keyword_by",
+          "named": true
+        },
+        {
+          "type": "keyword_hash",
+          "named": true
+        },
+        {
+          "type": "keyword_partition",
+          "named": true
+        },
+        {
+          "type": "keyword_partitioned",
+          "named": true
+        },
+        {
+          "type": "keyword_range",
           "named": true
         }
       ]
@@ -4247,6 +4490,29 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "table_sort",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "keyword_by",
+          "named": true
+        },
+        {
+          "type": "keyword_sort",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -4935,6 +5201,10 @@
     "named": true
   },
   {
+    "type": "keyword_avro",
+    "named": true
+  },
+  {
     "type": "keyword_begin",
     "named": true
   },
@@ -4968,6 +5238,10 @@
   },
   {
     "type": "keyword_bytea",
+    "named": true
+  },
+  {
+    "type": "keyword_cached",
     "named": true
   },
   {
@@ -5007,6 +5281,10 @@
     "named": true
   },
   {
+    "type": "keyword_csv",
+    "named": true
+  },
+  {
     "type": "keyword_current",
     "named": true
   },
@@ -5032,6 +5310,10 @@
   },
   {
     "type": "keyword_delete",
+    "named": true
+  },
+  {
+    "type": "keyword_delimited",
     "named": true
   },
   {
@@ -5063,6 +5345,10 @@
     "named": true
   },
   {
+    "type": "keyword_escaped",
+    "named": true
+  },
+  {
     "type": "keyword_except",
     "named": true
   },
@@ -5075,7 +5361,15 @@
     "named": true
   },
   {
+    "type": "keyword_external",
+    "named": true
+  },
+  {
     "type": "keyword_false",
+    "named": true
+  },
+  {
+    "type": "keyword_fields",
     "named": true
   },
   {
@@ -5096,6 +5390,10 @@
   },
   {
     "type": "keyword_force",
+    "named": true
+  },
+  {
+    "type": "keyword_format",
     "named": true
   },
   {
@@ -5187,6 +5485,10 @@
     "named": true
   },
   {
+    "type": "keyword_jsonfile",
+    "named": true
+  },
+  {
     "type": "keyword_key",
     "named": true
   },
@@ -5204,6 +5506,14 @@
   },
   {
     "type": "keyword_limit",
+    "named": true
+  },
+  {
+    "type": "keyword_lines",
+    "named": true
+  },
+  {
+    "type": "keyword_location",
     "named": true
   },
   {
@@ -5259,6 +5569,10 @@
     "named": true
   },
   {
+    "type": "keyword_orc",
+    "named": true
+  },
+  {
     "type": "keyword_order",
     "named": true
   },
@@ -5279,7 +5593,15 @@
     "named": true
   },
   {
+    "type": "keyword_parquet",
+    "named": true
+  },
+  {
     "type": "keyword_partition",
+    "named": true
+  },
+  {
+    "type": "keyword_partitioned",
     "named": true
   },
   {
@@ -5296,6 +5618,10 @@
   },
   {
     "type": "keyword_range",
+    "named": true
+  },
+  {
+    "type": "keyword_rcfile",
     "named": true
   },
   {
@@ -5320,6 +5646,10 @@
   },
   {
     "type": "keyword_replace",
+    "named": true
+  },
+  {
+    "type": "keyword_replication",
     "named": true
   },
   {
@@ -5355,6 +5685,10 @@
     "named": true
   },
   {
+    "type": "keyword_sequencefile",
+    "named": true
+  },
+  {
     "type": "keyword_set",
     "named": true
   },
@@ -5363,11 +5697,23 @@
     "named": true
   },
   {
+    "type": "keyword_sort",
+    "named": true
+  },
+  {
     "type": "keyword_spgist",
     "named": true
   },
   {
+    "type": "keyword_stored",
+    "named": true
+  },
+  {
     "type": "keyword_table",
+    "named": true
+  },
+  {
+    "type": "keyword_tblproperties",
     "named": true
   },
   {
@@ -5379,7 +5725,15 @@
     "named": true
   },
   {
+    "type": "keyword_terminated",
+    "named": true
+  },
+  {
     "type": "keyword_text",
+    "named": true
+  },
+  {
+    "type": "keyword_textfile",
     "named": true
   },
   {
@@ -5408,6 +5762,10 @@
   },
   {
     "type": "keyword_unbounded",
+    "named": true
+  },
+  {
+    "type": "keyword_uncached",
     "named": true
   },
   {

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -697,12 +697,10 @@ CREATE TABLE type_test (
           type: (keyword_bigserial))
         (column_definition
           name: (identifier)
-          type: (int
-            (keyword_int)))
+          type: (int (keyword_int)))
         (column_definition
           name: (identifier)
-          type: (int
-            (keyword_int)))
+          type: (int (keyword_int)))
         (column_definition
           name: (identifier)
           type: (bigint
@@ -965,3 +963,67 @@ CREATE TABLE tableName AS SELECT * FROM otherTable;
         (relation
           (table_reference
             name: (identifier)))))))
+
+================================================================================
+Create hive table
+================================================================================
+
+CREATE EXTERNAL TABLE tab (col int)
+PARTITIONED BY (col int)
+SORT BY (col)
+ROW FORMAT DELIMITED FIELDS TERMINATED BY ';' ESCAPED BY '"'
+LINES TERMINATED BY '\n'
+STORED AS PARQUET
+LOCATION '/path/data'
+CACHED IN 'pool1' WITH REPLICATION = 2
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_table
+      (keyword_create)
+      (keyword_external)
+      (keyword_table)
+      (table_reference
+        name: (identifier))
+      (column_definitions
+        (column_definition
+          name: (identifier)
+          type: (int (keyword_int))))
+      (table_partition
+        (keyword_partitioned)
+        (keyword_by)
+        (column_definitions
+          (column_definition
+            name: (identifier)
+            type: (int (keyword_int)))))
+      (table_sort
+        (keyword_sort)
+        (keyword_by)
+        (identifier))
+      (row_format
+        (keyword_row)
+        (keyword_format)
+        (keyword_delimited)
+        (keyword_fields)
+        (keyword_terminated)
+        (keyword_by)
+        (keyword_escaped)
+        (keyword_by)
+        (keyword_lines)
+        (keyword_terminated)
+        (keyword_by))
+      (stored_as
+        (keyword_stored)
+        (keyword_as)
+        (keyword_parquet))
+      (storage_location
+        (keyword_location)
+        path: (identifier)
+        (keyword_cached)
+        (keyword_in)
+        pool: (identifier)
+        (keyword_with)
+        (keyword_replication)
+        value: (literal)))))


### PR DESCRIPTION
This PR adds hive specific syntax for `CREATE TABLE` statements following the Impala syntax.

Hive style databases have an even more diverse set of SQL statements. I have tried to integrate them into the current syntax as smooth as possible. I have created a new node called `table_settings` with should include most of the new statements. Some of them are also supported by MySQL and Postgres (e.g. `PARTITION|PARTITIONED BY`). I also modified a bit the `TABLEPROPERTIES` since the `TBLPROPERTIES` of are quite similar.

Here is the reference statement that I tried to implement:
```SQL
CREATE [EXTERNAL] TABLE [IF NOT EXISTS] [db_name.]table_name
  (col_name data_type
    [constraint_specification]
    [COMMENT 'col_comment']
    [, ...]
  )
  [PARTITIONED BY (col_name data_type, ...)]
  [SORT BY ([column [, column ...]])]
  [ROW FORMAT row_format]
  [STORED AS file_format]
  [LOCATION 'hdfs_path']
  [CACHED IN 'pool_name' [WITH REPLICATION = integer] | UNCACHED]
  [TBLPROPERTIES ('key1'='value1', 'key2'='value2', ...)]
```
Note: i have excluded `COMMENT` and `SERDE_PROPERTIES` for now
Note2: Snowflake, Impala, AWS Athena, Hive, Datafusion (maybe BigQuery) share alot of these statements in slightly different fashion. I only have access to Impala, Athena and Snowflake for testing purposes.

Fixes #69 

Sorry for this huge PR. Next time I will try to cut it down into smaller pieces.

References:
https://impala.apache.org/docs/build/html/topics/impala_create_table.html