### PR TITLE
feat: Parse float

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1670,6 +1670,7 @@ module.exports = grammar({
       $._double_quote_string,
     ),
     _number: _ => /\d+/,
+    _decimal_number: _ => /\d*[.]?\d*/,
     bang: _ => '!',
 
     identifier: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -1672,9 +1672,9 @@ module.exports = grammar({
     ),
     _number: _ => /\d+/,
     _decimal_number: $ => choice(
-        seq(".", $._number),
-        seq($._number, ".", $._number),
-        seq($._number, "."),
+        seq(optional("-"), ".", $._number),
+        seq(optional("-"), $._number, ".", $._number),
+        seq(optional("-"), $._number, "."),
     ),
 
     bang: _ => '!',

--- a/grammar.js
+++ b/grammar.js
@@ -1658,6 +1658,7 @@ module.exports = grammar({
     literal: $ => prec(2,
       choice(
         $._number,
+        $._decimal_number,
         $._literal_string,
         $.keyword_true,
         $.keyword_false,
@@ -1670,7 +1671,12 @@ module.exports = grammar({
       $._double_quote_string,
     ),
     _number: _ => /\d+/,
-    _decimal_number: _ => /\d*[.]?\d*/,
+    _decimal_number: $ => choice(
+        seq(".", $._number),
+        seq($._number, ".", $._number),
+        seq($._number, "."),
+    ),
+
     bang: _ => '!',
 
     identifier: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9097,6 +9097,10 @@
       "type": "PATTERN",
       "value": "\\d+"
     },
+    "_decimal_number": {
+      "type": "PATTERN",
+      "value": "\\d*[.]?\\d*"
+    },
     "bang": {
       "type": "STRING",
       "value": "!"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9033,6 +9033,10 @@
           },
           {
             "type": "SYMBOL",
+            "name": "_decimal_number"
+          },
+          {
+            "type": "SYMBOL",
             "name": "_literal_string"
           },
           {
@@ -9098,8 +9102,52 @@
       "value": "\\d+"
     },
     "_decimal_number": {
-      "type": "PATTERN",
-      "value": "\\d*[.]?\\d*"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_number"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_number"
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_number"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_number"
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            }
+          ]
+        }
+      ]
     },
     "bang": {
       "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9108,21 +9108,16 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "."
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_number"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_number"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "-"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "STRING",
@@ -9137,6 +9132,47 @@
         {
           "type": "SEQ",
           "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "-"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_number"
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_number"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "-"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
             {
               "type": "SYMBOL",
               "name": "_number"

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -2184,3 +2184,32 @@ SELECT array[1, 2, 3 + 4, '5'::int, int_please()];
                 (keyword_int)))
             (invocation
               (identifier))))))))
+
+================================================================================
+Select with floats
+================================================================================
+
+SELECT a + 3.1415 from b where a >= 3.14
+
+--------------------------------------------------------------------------------
+(program
+  (statement
+  (select
+    (keyword_select)
+    (select_expression
+      (term
+        value: (binary_expression
+          left: (field
+            name: (identifier))
+          right: (literal)))))
+  (from
+    (keyword_from)
+    (relation
+      (table_reference
+        name: (identifier)))
+    (where
+      (keyword_where)
+      predicate: (binary_expression
+        left: (field
+          name: (identifier))
+        right: (literal))))))


### PR DESCRIPTION
Fixes #81

I have added the regex. Where should the node go?
When I add them to L1573:
```javascript
    _expression: $ => prec(1,
      choice(
        $.literal,
        $._decimal_number,
        $.field,
        $.parameter,
        $.list,
        $.case,
        $.window_function,
        $.subquery,
        $.cast,
        alias($.implicit_cast, $.cast),
        $._aggregate_function,
        $.invocation,
        $.binary_expression,
        $.unary_expression,
        $.array,
      )
    ),
```

Then a lot of tests fail, because instead of matching on `all_fields` it matches to `binary_expression`. This has probably to do with the `prec()` of this node.