### PR TITLE
feat(pg): add interval parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1233,8 +1233,7 @@ module.exports = grammar({
       $._type,
     ),
 
-
-    _interval_definitions: $ => repeat1(
+    interval_definitions: $ => repeat1(
          $._interval_definition
     ),
 
@@ -1277,7 +1276,7 @@ module.exports = grammar({
         $.keyword_interval,
         seq(
             "'",
-            $._interval_definitions,
+            $.interval_definitions,
             "'",
         ),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -277,6 +277,7 @@ module.exports = grammar({
         make_keyword('zone')
       ),
     ),
+    keyword_interval: _ => make_keyword("interval"),
 
     keyword_geometry: _ => make_keyword("geometry"),
     keyword_geography: _ => make_keyword("geography"),
@@ -327,6 +328,7 @@ module.exports = grammar({
       $.keyword_datetime,
       $.keyword_timestamp,
       $.keyword_timestamptz,
+      $.keyword_interval,
 
       $.keyword_geometry,
       $.keyword_geography,
@@ -1231,6 +1233,52 @@ module.exports = grammar({
       $._type,
     ),
 
+
+    _interval_definitions: $ => repeat1(
+         $._interval_definition
+    ),
+
+    _interval_definition: $ => seq(
+        $._number,
+        choice(
+            "millennium",
+            "century",
+            "decade",
+            "year",
+            "month",
+            "week",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "millisecond",
+            "microsecond",
+            "y",
+            "m",
+            "d",
+            "H",
+            "M",
+            "S",
+            "years",
+            "months",
+            "weeks",
+            "days",
+            "hours",
+            "minutes",
+            "seconds",
+        ),
+    ),
+
+    // Postgres syntax for intervals
+    interval: $ => seq(
+        $.keyword_interval,
+        seq(
+            "'",
+            $._interval_definitions,
+            "'",
+        ),
+    ),
+
     cast: $ => seq(
       field('name', alias($.keyword_cast, $.identifier)),
       '(',
@@ -1586,6 +1634,7 @@ module.exports = grammar({
         $.binary_expression,
         $.unary_expression,
         $.array,
+        $.interval,
       )
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1267,6 +1267,9 @@ module.exports = grammar({
             "minutes",
             "seconds",
         ),
+        optional(
+            "ago",
+        ),
     ),
 
     // Postgres syntax for intervals

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6591,7 +6591,7 @@
         }
       ]
     },
-    "_interval_definitions": {
+    "interval_definitions": {
       "type": "REPEAT1",
       "content": {
         "type": "SYMBOL",
@@ -6740,7 +6740,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_interval_definitions"
+              "name": "interval_definitions"
             },
             {
               "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1198,6 +1198,10 @@
         }
       ]
     },
+    "keyword_interval": {
+      "type": "PATTERN",
+      "value": "interval|INTERVAL"
+    },
     "keyword_geometry": {
       "type": "PATTERN",
       "value": "geometry|GEOMETRY"
@@ -1348,6 +1352,10 @@
         {
           "type": "SYMBOL",
           "name": "keyword_timestamptz"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_interval"
         },
         {
           "type": "SYMBOL",
@@ -6583,6 +6591,153 @@
         }
       ]
     },
+    "_interval_definitions": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_interval_definition"
+      }
+    },
+    "_interval_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_number"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "millennium"
+            },
+            {
+              "type": "STRING",
+              "value": "century"
+            },
+            {
+              "type": "STRING",
+              "value": "decade"
+            },
+            {
+              "type": "STRING",
+              "value": "year"
+            },
+            {
+              "type": "STRING",
+              "value": "month"
+            },
+            {
+              "type": "STRING",
+              "value": "week"
+            },
+            {
+              "type": "STRING",
+              "value": "day"
+            },
+            {
+              "type": "STRING",
+              "value": "hour"
+            },
+            {
+              "type": "STRING",
+              "value": "minute"
+            },
+            {
+              "type": "STRING",
+              "value": "second"
+            },
+            {
+              "type": "STRING",
+              "value": "millisecond"
+            },
+            {
+              "type": "STRING",
+              "value": "microsecond"
+            },
+            {
+              "type": "STRING",
+              "value": "y"
+            },
+            {
+              "type": "STRING",
+              "value": "m"
+            },
+            {
+              "type": "STRING",
+              "value": "d"
+            },
+            {
+              "type": "STRING",
+              "value": "H"
+            },
+            {
+              "type": "STRING",
+              "value": "M"
+            },
+            {
+              "type": "STRING",
+              "value": "S"
+            },
+            {
+              "type": "STRING",
+              "value": "years"
+            },
+            {
+              "type": "STRING",
+              "value": "months"
+            },
+            {
+              "type": "STRING",
+              "value": "weeks"
+            },
+            {
+              "type": "STRING",
+              "value": "days"
+            },
+            {
+              "type": "STRING",
+              "value": "hours"
+            },
+            {
+              "type": "STRING",
+              "value": "minutes"
+            },
+            {
+              "type": "STRING",
+              "value": "seconds"
+            }
+          ]
+        }
+      ]
+    },
+    "interval": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_interval"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "'"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_interval_definitions"
+            },
+            {
+              "type": "STRING",
+              "value": "'"
+            }
+          ]
+        }
+      ]
+    },
     "cast": {
       "type": "SEQ",
       "members": [
@@ -8090,6 +8245,10 @@
           {
             "type": "SYMBOL",
             "name": "array"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "interval"
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6709,6 +6709,18 @@
               "value": "seconds"
             }
           ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "ago"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5284,6 +5284,10 @@
     "named": false
   },
   {
+    "type": "ago",
+    "named": false
+  },
+  {
     "type": "bang",
     "named": true
   },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -139,6 +139,10 @@
             "named": true
           },
           {
+            "type": "keyword_interval",
+            "named": true
+          },
+          {
             "type": "keyword_json",
             "named": true
           },
@@ -255,6 +259,10 @@
         },
         {
           "type": "group_concat",
+          "named": true
+        },
+        {
+          "type": "interval",
           "named": true
         },
         {
@@ -467,6 +475,10 @@
           "named": true
         },
         {
+          "type": "interval",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -545,6 +557,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -647,6 +663,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -814,6 +834,10 @@
             "named": true
           },
           {
+            "type": "interval",
+            "named": true
+          },
+          {
             "type": "invocation",
             "named": true
           },
@@ -883,6 +907,10 @@
         },
         {
           "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "interval",
           "named": true
         },
         {
@@ -983,6 +1011,10 @@
             "named": true
           },
           {
+            "type": "interval",
+            "named": true
+          },
+          {
             "type": "invocation",
             "named": true
           },
@@ -1070,6 +1102,10 @@
           "named": true
         },
         {
+          "type": "interval",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -1111,6 +1147,10 @@
         },
         {
           "type": "keyword_geometry",
+          "named": true
+        },
+        {
+          "type": "keyword_interval",
           "named": true
         },
         {
@@ -1375,6 +1415,10 @@
           },
           {
             "type": "keyword_geometry",
+            "named": true
+          },
+          {
+            "type": "keyword_interval",
             "named": true
           },
           {
@@ -1679,6 +1723,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -2578,6 +2626,10 @@
           "named": true
         },
         {
+          "type": "interval",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -2668,6 +2720,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -2877,6 +2933,21 @@
     }
   },
   {
+    "type": "interval",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_interval",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "invocation",
     "named": true,
     "fields": {
@@ -2920,6 +2991,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -3007,6 +3082,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -3223,6 +3302,10 @@
           "named": true
         },
         {
+          "type": "interval",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -3354,6 +3437,10 @@
         },
         {
           "type": "group_concat",
+          "named": true
+        },
+        {
+          "type": "interval",
           "named": true
         },
         {
@@ -3637,6 +3724,10 @@
           "named": true
         },
         {
+          "type": "interval",
+          "named": true
+        },
+        {
           "type": "invocation",
           "named": true
         },
@@ -3737,6 +3828,10 @@
         },
         {
           "type": "group_concat",
+          "named": true
+        },
+        {
+          "type": "interval",
           "named": true
         },
         {
@@ -4562,6 +4657,10 @@
             "named": true
           },
           {
+            "type": "interval",
+            "named": true
+          },
+          {
             "type": "invocation",
             "named": true
           },
@@ -4702,6 +4801,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -4872,6 +4975,10 @@
           },
           {
             "type": "group_concat",
+            "named": true
+          },
+          {
+            "type": "interval",
             "named": true
           },
           {
@@ -5149,6 +5256,18 @@
     "named": false
   },
   {
+    "type": "H",
+    "named": false
+  },
+  {
+    "type": "M",
+    "named": false
+  },
+  {
+    "type": "S",
+    "named": false
+  },
+  {
     "type": "[",
     "named": false
   },
@@ -5167,6 +5286,34 @@
   {
     "type": "bang",
     "named": true
+  },
+  {
+    "type": "century",
+    "named": false
+  },
+  {
+    "type": "d",
+    "named": false
+  },
+  {
+    "type": "day",
+    "named": false
+  },
+  {
+    "type": "days",
+    "named": false
+  },
+  {
+    "type": "decade",
+    "named": false
+  },
+  {
+    "type": "hour",
+    "named": false
+  },
+  {
+    "type": "hours",
+    "named": false
   },
   {
     "type": "keyword_add",
@@ -5462,6 +5609,10 @@
   },
   {
     "type": "keyword_intersect",
+    "named": true
+  },
+  {
+    "type": "keyword_interval",
     "named": true
   },
   {
@@ -5827,6 +5978,66 @@
   {
     "type": "keyword_zerofill",
     "named": true
+  },
+  {
+    "type": "m",
+    "named": false
+  },
+  {
+    "type": "microsecond",
+    "named": false
+  },
+  {
+    "type": "millennium",
+    "named": false
+  },
+  {
+    "type": "millisecond",
+    "named": false
+  },
+  {
+    "type": "minute",
+    "named": false
+  },
+  {
+    "type": "minutes",
+    "named": false
+  },
+  {
+    "type": "month",
+    "named": false
+  },
+  {
+    "type": "months",
+    "named": false
+  },
+  {
+    "type": "second",
+    "named": false
+  },
+  {
+    "type": "seconds",
+    "named": false
+  },
+  {
+    "type": "week",
+    "named": false
+  },
+  {
+    "type": "weeks",
+    "named": false
+  },
+  {
+    "type": "y",
+    "named": false
+  },
+  {
+    "type": "year",
+    "named": false
+  },
+  {
+    "type": "years",
+    "named": false
   },
   {
     "type": "||",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2937,15 +2937,24 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "interval_definitions",
+          "named": true
+        },
         {
           "type": "keyword_interval",
           "named": true
         }
       ]
     }
+  },
+  {
+    "type": "interval_definitions",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "invocation",

--- a/test/corpus/casting.txt
+++ b/test/corpus/casting.txt
@@ -154,3 +154,27 @@ SELECT CAST ("1" AS UNSIGNED INTEGER);
             (int
               (keyword_unsigned)
               (keyword_int))))))))
+
+================================================================================
+Cast intervals
+================================================================================
+
+SELECT '1 day 10 seconds'::INTERVAL, CAST('1 month' AS INTERVAL)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (cast
+            (literal)
+            (keyword_interval)))
+        (term
+          value: (cast
+            name: (identifier)
+            parameter: (literal)
+            (keyword_as)
+            (keyword_interval)))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -2213,3 +2213,20 @@ SELECT a + 3.1415 from b where a >= 3.14
         left: (field
           name: (identifier))
         right: (literal))))))
+
+================================================================================
+Select intervals
+================================================================================
+
+SELECT interval '1m'
+
+--------------------------------------------------------------------------------
+(program
+  (statement
+  (select
+    (keyword_select)
+    (select_expression
+      (term
+        value: (interval
+          (keyword_interval)
+          (interval_definitions)))))))


### PR DESCRIPTION
Postgres interval parsing like:
`select '1 day'::interval`
or
`SELECT timestamp with time zone '2005-04-02 12:00:00-07' + interval '24 hours'`