### PR TITLE
fix: partially quoted expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1245,7 +1245,10 @@ module.exports = grammar({
             '.',
           ),
         ),
-        field('name', $.identifier),
+        choice(
+            field('name', $.identifier),
+            field('name', alias($._double_quote_string, $.identifier)),
+        ),
       ),
     ),
 
@@ -1739,9 +1742,11 @@ module.exports = grammar({
       ),
     ),
     _double_quote_string: _ => seq('"', /[^"]*/, '"'),
-    _literal_string: $ => choice(
-      seq("'", /[^']*/, "'"),
-      $._double_quote_string,
+    _literal_string: $ => prec(1,
+        choice(
+            seq("'", /[^']*/, "'"),
+            $._double_quote_string,
+        ),
     ),
     _number: _ => /\d+/,
     _decimal_number: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6659,12 +6659,30 @@
             ]
           },
           {
-            "type": "FIELD",
-            "name": "name",
-            "content": {
-              "type": "SYMBOL",
-              "name": "identifier"
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "name",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "name",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_double_quote_string"
+                  },
+                  "named": true,
+                  "value": "identifier"
+                }
+              }
+            ]
           }
         ]
       }
@@ -9338,30 +9356,34 @@
       ]
     },
     "_literal_string": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "'"
-            },
-            {
-              "type": "PATTERN",
-              "value": "[^']*"
-            },
-            {
-              "type": "STRING",
-              "value": "'"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_double_quote_string"
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "'"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^']*"
+              },
+              {
+                "type": "STRING",
+                "value": "'"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_double_quote_string"
+          }
+        ]
+      }
     },
     "_number": {
       "type": "PATTERN",

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -245,6 +245,30 @@ FROM my_table "My Table";
         table_alias: (identifier)))))
 
 ================================================================================
+Select with quoted column
+================================================================================
+
+SELECT tab."COL" FROM tab;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+            table_alias: (identifier)
+            name: (identifier)))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier))))))
+
+
+================================================================================
 Simple select with where
 ================================================================================
 


### PR DESCRIPTION
This fixes statements like
`select tab."Col" from tab`

In a previous commit we already got the following variations working:
`select "Schem"."Tabl"."CLMN" from "Tabl"`
and
`select "Col" from tab`

Fixes #93 