### PR TITLE
feat: Implement MariaDB `ALTER TABLE` syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -67,6 +67,7 @@ module.exports = grammar({
     keyword_primary: _ => make_keyword("primary"),
     keyword_create: _ => make_keyword("create"),
     keyword_alter: _ => make_keyword("alter"),
+    keyword_change: _ => make_keyword("change"),
     keyword_drop: _ => make_keyword("drop"),
     keyword_add: _ => make_keyword("add"),
     keyword_table: _ => make_keyword("table"),
@@ -712,6 +713,7 @@ module.exports = grammar({
     _alter_specifications: $ =>  choice(
       $.add_column,
       $.alter_column,
+      $.change_column,
       $.drop_column,
       $.rename_object,
       $.rename_column,
@@ -764,6 +766,17 @@ module.exports = grammar({
           $.keyword_default,
         ),
       ),
+    ),
+
+    change_column: $ => seq(
+      $.keyword_change,
+      optional(
+        $.keyword_column,
+      ),
+      optional($._if_exists),
+      field('old_name', $.identifier),
+      $.column_definition
+      // TODO: FIRST | AFTER col_name
     ),
 
     drop_column: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -698,28 +698,25 @@ module.exports = grammar({
       $.table_reference,
       choice(
         seq(
-          choice(
-            $.add_column,
-            $.alter_column,
-            $.drop_column,
-          ),
+          $._alter_specifications,
           repeat(
             seq(
               ",",
-              choice(
-                $.add_column,
-                $.alter_column,
-                $.drop_column,
-              )
+              $._alter_specifications
             )
           )
         ),
-        // some operations may not be chained to others
-        $.rename_object,
-        $.rename_column,
-        $.set_schema,
-        $.change_ownership,
       ),
+    ),
+
+    _alter_specifications: $ =>  choice(
+      $.add_column,
+      $.alter_column,
+      $.drop_column,
+      $.rename_object,
+      $.rename_column,
+      $.set_schema,
+      $.change_ownership,
     ),
 
     add_column: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -68,6 +68,7 @@ module.exports = grammar({
     keyword_create: _ => make_keyword("create"),
     keyword_alter: _ => make_keyword("alter"),
     keyword_change: _ => make_keyword("change"),
+    keyword_modify: _ => make_keyword("modify"),
     keyword_drop: _ => make_keyword("drop"),
     keyword_add: _ => make_keyword("add"),
     keyword_table: _ => make_keyword("table"),
@@ -710,9 +711,10 @@ module.exports = grammar({
       ),
     ),
 
-    _alter_specifications: $ =>  choice(
+    _alter_specifications: $ => choice(
       $.add_column,
       $.alter_column,
+      $.modify_column,
       $.change_column,
       $.drop_column,
       $.rename_object,
@@ -766,6 +768,16 @@ module.exports = grammar({
           $.keyword_default,
         ),
       ),
+    ),
+
+    modify_column: $ => seq(
+      $.keyword_modify,
+      optional(
+        $.keyword_column,
+      ),
+      optional($._if_exists),
+      $.column_definition
+      // TODO: FIRST | AFTER col_name
     ),
 
     change_column: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -134,6 +134,7 @@ module.exports = grammar({
     keyword_over: _ => make_keyword("over"),
     keyword_nulls: _ => make_keyword("nulls"),
     keyword_first: _ => make_keyword("first"),
+    keyword_after: _ => make_keyword("after"),
     keyword_last: _ => make_keyword("last"),
     keyword_window: _ => make_keyword("window"),
     keyword_range: _ => make_keyword("range"),
@@ -730,6 +731,7 @@ module.exports = grammar({
       ),
       optional($._if_not_exists),
       $.column_definition,
+      optional($.column_position),
     ),
 
     alter_column: $ => seq(
@@ -776,8 +778,8 @@ module.exports = grammar({
         $.keyword_column,
       ),
       optional($._if_exists),
-      $.column_definition
-      // TODO: FIRST | AFTER col_name
+      $.column_definition,
+      optional($.column_position),
     ),
 
     change_column: $ => seq(
@@ -787,8 +789,16 @@ module.exports = grammar({
       ),
       optional($._if_exists),
       field('old_name', $.identifier),
-      $.column_definition
-      // TODO: FIRST | AFTER col_name
+      $.column_definition,
+      optional($.column_position),
+    ),
+
+    column_position: $ => choice(
+      $.keyword_first,
+      seq(
+        $.keyword_after,
+        field('col_name', $.identifier),
+      ),
     ),
 
     drop_column: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -410,6 +410,10 @@
       "type": "PATTERN",
       "value": "first|FIRST"
     },
+    "keyword_after": {
+      "type": "PATTERN",
+      "value": "after|AFTER"
+    },
     "keyword_last": {
       "type": "PATTERN",
       "value": "last|LAST"
@@ -4521,6 +4525,18 @@
         {
           "type": "SYMBOL",
           "name": "column_definition"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "column_position"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -4686,6 +4702,18 @@
         {
           "type": "SYMBOL",
           "name": "column_definition"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "column_position"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -4731,6 +4759,44 @@
         {
           "type": "SYMBOL",
           "name": "column_definition"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "column_position"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "column_position": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_first"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_after"
+            },
+            {
+              "type": "FIELD",
+              "name": "col_name",
+              "content": {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4413,21 +4413,8 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "add_column"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "alter_column"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "drop_column"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_alter_specifications"
                 },
                 {
                   "type": "REPEAT",
@@ -4439,44 +4426,48 @@
                         "value": ","
                       },
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "add_column"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "alter_column"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "drop_column"
-                          }
-                        ]
+                        "type": "SYMBOL",
+                        "name": "_alter_specifications"
                       }
                     ]
                   }
                 }
               ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "rename_object"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "rename_column"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "set_schema"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "change_ownership"
             }
           ]
+        }
+      ]
+    },
+    "_alter_specifications": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "add_column"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "alter_column"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "drop_column"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rename_object"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rename_column"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_schema"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "change_ownership"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -146,6 +146,10 @@
       "type": "PATTERN",
       "value": "change|CHANGE"
     },
+    "keyword_modify": {
+      "type": "PATTERN",
+      "value": "modify|MODIFY"
+    },
     "keyword_drop": {
       "type": "PATTERN",
       "value": "drop|DROP"
@@ -4455,6 +4459,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "modify_column"
+        },
+        {
+          "type": "SYMBOL",
           "name": "change_column"
         },
         {
@@ -4641,6 +4649,43 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "modify_column": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_modify"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_column"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_if_exists"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "column_definition"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -142,6 +142,10 @@
       "type": "PATTERN",
       "value": "alter|ALTER"
     },
+    "keyword_change": {
+      "type": "PATTERN",
+      "value": "change|CHANGE"
+    },
     "keyword_drop": {
       "type": "PATTERN",
       "value": "drop|DROP"
@@ -4451,6 +4455,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "change_column"
+        },
+        {
+          "type": "SYMBOL",
           "name": "drop_column"
         },
         {
@@ -4633,6 +4641,51 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "change_column": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_change"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_column"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_if_exists"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "old_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "column_definition"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -349,6 +349,10 @@
           "named": true
         },
         {
+          "type": "change_column",
+          "named": true
+        },
+        {
           "type": "change_ownership",
           "named": true
         },
@@ -1259,6 +1263,48 @@
         },
         {
           "type": "window_function",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "change_column",
+    "named": true,
+    "fields": {
+      "old_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "column_definition",
+          "named": true
+        },
+        {
+          "type": "keyword_change",
+          "named": true
+        },
+        {
+          "type": "keyword_column",
+          "named": true
+        },
+        {
+          "type": "keyword_exists",
+          "named": true
+        },
+        {
+          "type": "keyword_if",
           "named": true
         }
       ]
@@ -5472,6 +5518,10 @@
   },
   {
     "type": "keyword_case",
+    "named": true
+  },
+  {
+    "type": "keyword_change",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -12,6 +12,10 @@
           "named": true
         },
         {
+          "type": "column_position",
+          "named": true
+        },
+        {
           "type": "keyword_add",
           "named": true
         },
@@ -1296,6 +1300,10 @@
           "named": true
         },
         {
+          "type": "column_position",
+          "named": true
+        },
+        {
           "type": "keyword_change",
           "named": true
         },
@@ -1635,6 +1643,36 @@
         },
         {
           "type": "constraints",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "column_position",
+    "named": true,
+    "fields": {
+      "col_name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_after",
+          "named": true
+        },
+        {
+          "type": "keyword_first",
           "named": true
         }
       ]
@@ -3666,6 +3704,10 @@
           "named": true
         },
         {
+          "type": "column_position",
+          "named": true
+        },
+        {
           "type": "keyword_column",
           "named": true
         },
@@ -5473,6 +5515,10 @@
   },
   {
     "type": "keyword_add",
+    "named": true
+  },
+  {
+    "type": "keyword_after",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -377,6 +377,10 @@
           "named": true
         },
         {
+          "type": "modify_column",
+          "named": true
+        },
+        {
           "type": "rename_column",
           "named": true
         },
@@ -3650,6 +3654,37 @@
     }
   },
   {
+    "type": "modify_column",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "column_definition",
+          "named": true
+        },
+        {
+          "type": "keyword_column",
+          "named": true
+        },
+        {
+          "type": "keyword_exists",
+          "named": true
+        },
+        {
+          "type": "keyword_if",
+          "named": true
+        },
+        {
+          "type": "keyword_modify",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "not_distinct_from",
     "named": true,
     "fields": {},
@@ -5794,6 +5829,10 @@
   },
   {
     "type": "keyword_materialized",
+    "named": true
+  },
+  {
+    "type": "keyword_modify",
     "named": true
   },
   {

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -122,6 +122,35 @@ ALTER TABLE my_table
   )))
 
 ==================
+Alter table and modify column changing type
+==================
+
+ALTER TABLE my_table
+  MODIFY COLUMN IF EXISTS val6 INT UNSIGNED NOT NULL;
+
+---
+
+(program
+ (statement
+  (alter_table
+   (keyword_alter)
+   (keyword_table)
+   (table_reference
+    name: (identifier))
+   (modify_column
+    (keyword_modify)
+    (keyword_column)
+    (keyword_if)
+    (keyword_exists)
+    (column_definition
+     name: (identifier)
+     type: (int 
+      (keyword_int)
+      (keyword_unsigned))
+     (keyword_not)
+     (keyword_null))))))
+
+==================
 Alter table and change column renaming and changing type
 ==================
 

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -122,6 +122,35 @@ ALTER TABLE my_table
   )))
 
 ==================
+Alter table and change column renaming and changing type
+==================
+
+ALTER TABLE my_table
+  CHANGE COLUMN IF EXISTS val3 val4 INT UNSIGNED NOT NULL;
+
+---
+
+(program
+ (statement
+  (alter_table
+   (keyword_alter)
+   (keyword_table)
+   (table_reference name: (identifier))
+   (change_column
+    (keyword_change)
+    (keyword_column)
+    (keyword_if)
+    (keyword_exists)
+    old_name: (identifier)
+    (column_definition
+     name: (identifier)
+     type: (int 
+      (keyword_int)
+      (keyword_unsigned))
+     (keyword_not)
+     (keyword_null))))))
+
+==================
 Alter table and alter column changing type, eliding column keyword
 ==================
 

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -52,6 +52,61 @@ ALTER TABLE my_table
    ))))
 
 ==================
+Alter table and add column first
+==================
+
+ALTER TABLE my_table
+  ADD val3 VARCHAR(100) NOT NULL FIRST;
+
+---
+
+(program
+ (statement
+  (alter_table
+   (keyword_alter)
+   (keyword_table)
+   (table_reference name: (identifier))
+   (add_column
+    (keyword_add)
+    (column_definition
+     name: (identifier)
+     type: (varchar
+      (keyword_varchar)
+      size: (literal))
+     (keyword_not)
+     (keyword_null))
+    (column_position
+     (keyword_first))))))
+
+==================
+Alter table and add column after column
+==================
+
+ALTER TABLE my_table
+  ADD val3 VARCHAR(100) NOT NULL AFTER val2;
+
+---
+
+(program
+ (statement
+  (alter_table
+   (keyword_alter)
+   (keyword_table)
+   (table_reference name: (identifier))
+   (add_column
+    (keyword_add)
+    (column_definition
+     name: (identifier)
+     type: (varchar
+      (keyword_varchar)
+      size: (literal))
+     (keyword_not)
+     (keyword_null))
+    (column_position
+     (keyword_after)
+     col_name: (identifier))))))
+
+==================
 Alter table and alter column setting default
 ==================
 
@@ -122,11 +177,11 @@ ALTER TABLE my_table
   )))
 
 ==================
-Alter table and modify column changing type
+Alter table and modify column changing type and position
 ==================
 
 ALTER TABLE my_table
-  MODIFY COLUMN IF EXISTS val6 INT UNSIGNED NOT NULL;
+  MODIFY COLUMN IF EXISTS val6 INT UNSIGNED NOT NULL AFTER val3;
 
 ---
 
@@ -148,7 +203,10 @@ ALTER TABLE my_table
       (keyword_int)
       (keyword_unsigned))
      (keyword_not)
-     (keyword_null))))))
+     (keyword_null))
+    (column_position
+     (keyword_after)
+     col_name: (identifier))))))
 
 ==================
 Alter table and change column renaming and changing type

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -299,7 +299,8 @@ Alter table and multiple
 ALTER TABLE IF EXISTS my_table
   ADD COLUMN IF NOT EXISTS val4 DATE,
   ALTER COLUMN val5 DROP NOT NULL, -- comment, ignore me!
-  DROP COLUMN IF EXISTS val6;
+  RENAME COLUMN val6 TO val7,
+  DROP COLUMN IF EXISTS val8;
 
 ---
 
@@ -326,6 +327,12 @@ ALTER TABLE IF EXISTS my_table
     (keyword_not)
     (keyword_null))
    (comment)
+   (rename_column
+    (keyword_rename)
+    (keyword_column)
+    old_name: (identifier)
+    (keyword_to)
+    new_name: (identifier))
    (drop_column
     (keyword_drop)
     (keyword_column)


### PR DESCRIPTION
# Implement MariaDB & MySQL `ALTER TABLE` syntax

Replacing the accidentally merged #98.

This PR is a draft just to show I'm working on that, since now other PRs have been merged and no parser code clashes await.

## Fixes:
- https://github.com/DerekStride/tree-sitter-sql/issues/82
- https://github.com/DerekStride/tree-sitter-sql/issues/83
- https://github.com/DerekStride/tree-sitter-sql/issues/89
- #71 

## PR contents:

- [fix: Lift `ALTER TABLE` combination restriction (only Postgres)](https://github.com/DerekStride/tree-sitter-sql/commit/be20ed053a6d0a6125e485f4796a488f91df987d)
  Resolves comment: https://github.com/DerekStride/tree-sitter-sql/issues/82#issuecomment-1416227381
- [feat: Add MariaDB/MySQL `ALTER TABLE ... CHANGE ...`](https://github.com/DerekStride/tree-sitter-sql/pull/99/commits/1124c5151320e6c1107ef7afc7f61b91690f0ebe)
  Fixes: https://github.com/DerekStride/tree-sitter-sql/issues/82
- [feat: Add MariaDB/MySQL `ALTER TABLE ... MODIFY ...`](https://github.com/DerekStride/tree-sitter-sql/pull/99/commits/409be47ae61daeac205be5448b1b69fb702e4915)
  Fixes: https://github.com/DerekStride/tree-sitter-sql/issues/89
- [feat: Add MariaDB/MySQL `ADD|CHANGE|MODIFY ... FIRST|AFTER ...`](https://github.com/DerekStride/tree-sitter-sql/pull/99/commits/393e0d35aad922a3bf4faa4ceccad2e401f7b2ab)
  Fixes: https://github.com/DerekStride/tree-sitter-sql/issues/83