### PR TITLE
Create Tables/views from CTE's

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -415,18 +415,20 @@ module.exports = grammar({
       $._drop_statement,
     ),
 
-    _dml_statement: $ => seq(
-      optional(
-        seq(
-          $.keyword_with,
-          $.cte,
-          repeat(
+    _cte: $ => seq(
+        $.keyword_with,
+        $.cte,
+        repeat(
             seq(
               ',',
               $.cte,
             ),
-          ),
         ),
+    ),
+
+    _dml_statement: $ => seq(
+      optional(
+          $._cte
       ),
       choice(
         $._select_statement,
@@ -610,7 +612,13 @@ module.exports = grammar({
               optional($.table_options),
               seq(
                   $.keyword_as,
-                  $._select_statement,
+                  choice(
+                      $._select_statement,
+                      seq(
+                          $._cte,
+                          $._select_statement,
+                      ),
+                  ),
               ),
           ),
        ),
@@ -623,7 +631,13 @@ module.exports = grammar({
       optional($._if_not_exists),
       $.table_reference,
       $.keyword_as,
-      $._select_statement,
+      choice(
+          $._select_statement,
+          seq(
+              $._cte,
+              $._select_statement,
+          ),
+      ),
     ),
 
     create_materialized_view: $ => prec.right(
@@ -635,7 +649,13 @@ module.exports = grammar({
         optional($._if_not_exists),
         $.table_reference,
         $.keyword_as,
-        $._select_statement,
+        choice(
+          $._select_statement,
+          seq(
+              $._cte,
+              $._select_statement,
+          ),
+        ),
         optional(
           choice(
             seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3336,6 +3336,35 @@
         }
       ]
     },
+    "_cte": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_with"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cte"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "cte"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "_dml_statement": {
       "type": "SEQ",
       "members": [
@@ -3343,33 +3372,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "keyword_with"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "cte"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "cte"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_cte"
             },
             {
               "type": "BLANK"
@@ -4060,8 +4064,26 @@
                       "name": "keyword_as"
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "_select_statement"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_select_statement"
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_cte"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "_select_statement"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
@@ -4115,8 +4137,26 @@
           "name": "keyword_as"
         },
         {
-          "type": "SYMBOL",
-          "name": "_select_statement"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_select_statement"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_cte"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_select_statement"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -4171,8 +4211,26 @@
             "name": "keyword_as"
           },
           {
-            "type": "SYMBOL",
-            "name": "_select_statement"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_select_statement"
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_cte"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_select_statement"
+                  }
+                ]
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -9752,4 +9810,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1963,6 +1963,10 @@
       "required": true,
       "types": [
         {
+          "type": "cte",
+          "named": true
+        },
+        {
           "type": "from",
           "named": true
         },
@@ -2054,6 +2058,10 @@
           "named": true
         },
         {
+          "type": "cte",
+          "named": true
+        },
+        {
           "type": "from",
           "named": true
         },
@@ -2114,6 +2122,10 @@
           "named": true
         },
         {
+          "type": "keyword_with",
+          "named": true
+        },
+        {
           "type": "row_format",
           "named": true
         },
@@ -2156,6 +2168,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "cte",
+          "named": true
+        },
         {
           "type": "from",
           "named": true
@@ -2206,6 +2222,10 @@
         },
         {
           "type": "keyword_view",
+          "named": true
+        },
+        {
+          "type": "keyword_with",
           "named": true
         },
         {

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -697,10 +697,12 @@ CREATE TABLE type_test (
           type: (keyword_bigserial))
         (column_definition
           name: (identifier)
-          type: (int (keyword_int)))
+          type: (int
+            (keyword_int)))
         (column_definition
           name: (identifier)
-          type: (int (keyword_int)))
+          type: (int
+            (keyword_int)))
         (column_definition
           name: (identifier)
           type: (bigint
@@ -965,6 +967,142 @@ CREATE TABLE tableName AS SELECT * FROM otherTable;
             name: (identifier)))))))
 
 ================================================================================
+Create table as select with cte
+================================================================================
+
+CREATE TABLE tableName AS WITH _cte AS (
+    SELECT a FROM b
+)
+SELECT * FROM _cte
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_table
+      (keyword_create)
+      (keyword_table)
+      (table_reference
+        (identifier))
+      (keyword_as)
+      (keyword_with)
+      (cte
+        (identifier)
+        (keyword_as)
+        (statement
+          (select
+            (keyword_select)
+            (select_expression
+              (term
+                (field
+                  (identifier)))))
+          (from
+            (keyword_from)
+            (relation
+              (table_reference
+                (identifier))))))
+      (select
+        (keyword_select)
+        (select_expression
+          (all_fields)))
+      (from
+        (keyword_from)
+        (relation
+          (table_reference
+            (identifier)))))))
+
+================================================================================
+Create view as select with cte
+================================================================================
+
+CREATE VIEW tableName AS WITH _cte AS (
+    SELECT a FROM b
+)
+SELECT * FROM _cte
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_view
+      (keyword_create)
+      (keyword_view)
+      (table_reference
+        (identifier))
+      (keyword_as)
+      (keyword_with)
+      (cte
+        (identifier)
+        (keyword_as)
+        (statement
+          (select
+            (keyword_select)
+            (select_expression
+              (term
+                (field
+                  (identifier)))))
+          (from
+            (keyword_from)
+            (relation
+              (table_reference
+                (identifier))))))
+      (select
+        (keyword_select)
+        (select_expression
+          (all_fields)))
+      (from
+        (keyword_from)
+        (relation
+          (table_reference
+            (identifier)))))))
+
+================================================================================
+Create materialized view as select with cte
+================================================================================
+
+CREATE MATERIALIZED VIEW tableName AS WITH _cte AS (
+    SELECT a FROM b
+)
+SELECT * FROM _cte
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_materialized_view
+      (keyword_create)
+      (keyword_materialized)
+      (keyword_view)
+      (table_reference
+        (identifier))
+      (keyword_as)
+      (keyword_with)
+      (cte
+        (identifier)
+        (keyword_as)
+        (statement
+          (select
+            (keyword_select)
+            (select_expression
+              (term
+                (field
+                  (identifier)))))
+          (from
+            (keyword_from)
+            (relation
+              (table_reference
+                (identifier))))))
+      (select
+        (keyword_select)
+        (select_expression
+          (all_fields)))
+      (from
+        (keyword_from)
+        (relation
+          (table_reference
+            (identifier)))))))
+
+================================================================================
 Create hive table
 ================================================================================
 
@@ -990,14 +1128,16 @@ CACHED IN 'pool1' WITH REPLICATION = 2
       (column_definitions
         (column_definition
           name: (identifier)
-          type: (int (keyword_int))))
+          type: (int
+            (keyword_int))))
       (table_partition
         (keyword_partitioned)
         (keyword_by)
         (column_definitions
           (column_definition
             name: (identifier)
-            type: (int (keyword_int)))))
+            type: (int
+              (keyword_int)))))
       (table_sort
         (keyword_sort)
         (keyword_by)


### PR DESCRIPTION
Fixes #104 

I am not 100% sure that the resulting AST is correct:

```
(program [0, 0] - [5, 0]
  (statement [0, 0] - [3, 1]
    (create_table [0, 0] - [3, 1]
      (keyword_create [0, 0] - [0, 6])
      (keyword_table [0, 7] - [0, 12])
      (table_reference [0, 13] - [0, 16]
        name: (identifier [0, 13] - [0, 16]))
      (keyword_as [0, 17] - [0, 19])
      (keyword_with [1, 0] - [1, 4])
      (cte [1, 5] - [3, 1]
        (identifier [1, 5] - [1, 9])
        (keyword_as [1, 10] - [1, 12])
        (statement [2, 4] - [2, 19]
          (select [2, 4] - [2, 12]
            (keyword_select [2, 4] - [2, 10])
            (select_expression [2, 11] - [2, 12]
              (term [2, 11] - [2, 12]
                value: (field [2, 11] - [2, 12]
                  name: (identifier [2, 11] - [2, 12])))))
          (from [2, 13] - [2, 19]
            (keyword_from [2, 13] - [2, 17])
            (relation [2, 18] - [2, 19]
              (table_reference [2, 18] - [2, 19]
                name: (identifier [2, 18] - [2, 19]))))))))
  (statement [4, 0] - [4, 19]
    (select [4, 0] - [4, 8]
      (keyword_select [4, 0] - [4, 6])
      (select_expression [4, 7] - [4, 8]
        (all_fields [4, 7] - [4, 8])))
    (from [4, 9] - [4, 19]
      (keyword_from [4, 9] - [4, 13])
      (relation [4, 14] - [4, 19]
        (table_reference [4, 14] - [4, 19]
          name: (identifier [4, 14] - [4, 19]))))))
```

Shouldn't the last `statement` be on the same level as the `cte` since it technically belongs to it?

This is the AST from 
```sql
create table tab as
with _cte as (
    select a from b
)
select * from _cte
```