### PR TITLE
feat: support single quotes in string literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1796,7 +1796,7 @@ module.exports = grammar({
     _double_quote_string: _ => seq('"', /[^"]*/, '"'),
     _literal_string: $ => prec(1,
         choice(
-            seq("'", /[^']*/, "'"),
+            seq("'", /([^']|'')*/, "'"),
             $._double_quote_string,
         ),
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9600,7 +9600,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "[^']*"
+                "value": "([^']|'')*"
               },
               {
                 "type": "STRING",

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -2283,3 +2283,51 @@ SELECT interval '1m'
         value: (interval
           (keyword_interval)
           (interval_definitions)))))))
+
+================================================================================
+Select with string literals containing single quotes
+================================================================================
+
+SELECT 'foo''bar';
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (literal))))))
+
+================================================================================
+Select with string literals starting/ending with single quotes
+================================================================================
+
+SELECT '''foo''';
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (literal))))))
+
+================================================================================
+Select with string literals containing consecutive single quotes
+================================================================================
+
+SELECT 'foo''''''bar';
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (literal))))))


### PR DESCRIPTION
`'foo''bar'` => literal `foo'bar`

- Not sure where the tests should go or if more are needed, but I put them in `select.txt` for now
- Ran `tree-sitter generate --abi 13 && tree-sitter test`, is that it?