### PR TITLE
feat: add bit datatype

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -223,6 +223,7 @@ module.exports = grammar({
     keyword_false: _ => make_keyword("false"),
 
     keyword_boolean: _ => make_keyword("boolean"),
+    keyword_bit: _ => make_keyword("bit"),
 
     keyword_smallserial: _ => choice(make_keyword("smallserial"),make_keyword("serial2")),
     keyword_serial: _ => choice(make_keyword("serial"),make_keyword("serial4")),
@@ -240,13 +241,14 @@ module.exports = grammar({
     keyword_precision: _ => make_keyword("precision"),
 
     keyword_money: _ => make_keyword("money"),
+    keyword_varying: _ => make_keyword("varying"),
 
     keyword_char: _ => choice(make_keyword("char"), make_keyword("character")),
-    keyword_varchar: _ => choice(
+    keyword_varchar: $ => choice(
       make_keyword("varchar"),
       seq(
         make_keyword("character"),
-        make_keyword("varying"),
+        $.keyword_varying,
       )
     ),
     keyword_text: _ => make_keyword("text"),
@@ -299,6 +301,7 @@ module.exports = grammar({
 
     _type: $ => choice(
       $.keyword_boolean,
+      $.bit,
 
       $.keyword_smallserial,
       $.keyword_serial,
@@ -356,6 +359,15 @@ module.exports = grammar({
     mediumint: $ => unsigned_type($, parametric_type($, $.keyword_mediumint)),
     int: $ => unsigned_type($, parametric_type($, $.keyword_int)),
     bigint: $ => unsigned_type($, parametric_type($, $.keyword_bigint)),
+
+    bit: $ => choice(
+        $.keyword_bit,
+        seq(
+            $.keyword_bit,
+            prec(0, parametric_type($, $.keyword_varying, ['precision'])),
+        ),
+        prec(1, parametric_type($, $.keyword_bit, ['precision'])),
+    ),
 
     // TODO: should qualify against /\\b(0?[1-9]|[1-4][0-9]|5[0-4])\\b/g
     float: $  => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -934,6 +934,10 @@
       "type": "PATTERN",
       "value": "boolean|BOOLEAN"
     },
+    "keyword_bit": {
+      "type": "PATTERN",
+      "value": "bit|BIT"
+    },
     "keyword_smallserial": {
       "type": "CHOICE",
       "members": [
@@ -1079,6 +1083,10 @@
       "type": "PATTERN",
       "value": "money|MONEY"
     },
+    "keyword_varying": {
+      "type": "PATTERN",
+      "value": "varying|VARYING"
+    },
     "keyword_char": {
       "type": "CHOICE",
       "members": [
@@ -1107,8 +1115,8 @@
               "value": "character|CHARACTER"
             },
             {
-              "type": "PATTERN",
-              "value": "varying|VARYING"
+              "type": "SYMBOL",
+              "name": "keyword_varying"
             }
           ]
         }
@@ -1268,6 +1276,10 @@
         {
           "type": "SYMBOL",
           "name": "keyword_boolean"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bit"
         },
         {
           "type": "SYMBOL",
@@ -2069,6 +2081,118 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "bit": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "keyword_bit"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "keyword_bit"
+            },
+            {
+              "type": "PREC",
+              "value": 0,
+              "content": {
+                "type": "PREC_RIGHT",
+                "value": 0,
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_varying"
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "keyword_varying"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "FIELD",
+                          "name": "precision",
+                          "content": {
+                            "type": "ALIAS",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "_natural_number"
+                            },
+                            "named": true,
+                            "value": "literal"
+                          }
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "PREC_RIGHT",
+            "value": 0,
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "keyword_bit"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "keyword_bit"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "FIELD",
+                      "name": "precision",
+                      "content": {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_natural_number"
+                        },
+                        "named": true,
+                        "value": "literal"
+                      }
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -87,6 +87,10 @@
             "named": true
           },
           {
+            "type": "bit",
+            "named": true
+          },
+          {
             "type": "char",
             "named": true
           },
@@ -886,6 +890,36 @@
     }
   },
   {
+    "type": "bit",
+    "named": true,
+    "fields": {
+      "precision": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "literal",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "keyword_bit",
+          "named": true
+        },
+        {
+          "type": "keyword_varying",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "case",
     "named": true,
     "fields": {},
@@ -1075,6 +1109,10 @@
         },
         {
           "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "bit",
           "named": true
         },
         {
@@ -1421,6 +1459,10 @@
         "types": [
           {
             "type": "bigint",
+            "named": true
+          },
+          {
+            "type": "bit",
             "named": true
           },
           {
@@ -3426,7 +3468,17 @@
   {
     "type": "keyword_varchar",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "keyword_varying",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "keyword_with",
@@ -5621,6 +5673,10 @@
     "named": true
   },
   {
+    "type": "keyword_bit",
+    "named": true
+  },
+  {
     "type": "keyword_boolean",
     "named": true
   },
@@ -6234,6 +6290,10 @@
   },
   {
     "type": "keyword_values",
+    "named": true
+  },
+  {
+    "type": "keyword_varying",
     "named": true
   },
   {

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -635,6 +635,9 @@ Create table with all types
 
 CREATE TABLE type_test (
   a_bool BOOLEAN,
+  a_bit BIT,
+  a_bit2 BIT(2),
+  a_bit3 BIT VARYING(2),
   a_smallser SMALLSERIAL,
   a_serial SERIAL,
   a_bigser BIGSERIAL,
@@ -686,6 +689,21 @@ CREATE TABLE type_test (
         (column_definition
           name: (identifier)
           type: (keyword_boolean))
+        (column_definition
+          name: (identifier)
+          type: (bit
+            (keyword_bit)))
+        (column_definition
+          name: (identifier)
+          type: (bit
+            (keyword_bit)
+            precision: (literal)))
+        (column_definition
+          name: (identifier)
+          type: (bit
+            (keyword_bit)
+            (keyword_varying)
+            precision: (literal)))
         (column_definition
           name: (identifier)
           type: (keyword_smallserial))
@@ -770,7 +788,8 @@ CREATE TABLE type_test (
         (column_definition
           name: (identifier)
           type: (varchar
-            (keyword_varchar)
+            (keyword_varchar
+              (keyword_varying))
             size: (literal)))
         (column_definition
           name: (identifier)


### PR DESCRIPTION
This PR extends #107 and includes also the variations for Postgres, MySQL and MariaDB. Thus, merging #107 is not necessary anymore, since there was not feedback in over a week.