### PR TITLE
WIP: Less permissive parenthesis

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1698,23 +1698,26 @@ module.exports = grammar({
     ),
 
     _expression: $ => prec(1,
-      choice(
-        $.literal,
-        $.field,
-        $.parameter,
-        $.list,
-        $.case,
-        $.window_function,
-        $.subquery,
-        $.cast,
-        alias($.implicit_cast, $.cast),
-        $._aggregate_function,
-        $.invocation,
-        $.binary_expression,
-        $.unary_expression,
-        $.array,
-        $.interval,
-      )
+        prec.left(
+            choice(
+                $.literal,
+                $.field,
+                $.parameter,
+                $.list,
+                $.case,
+                $.window_function,
+                $.subquery,
+                $.cast,
+                alias($.implicit_cast, $.cast),
+                $._aggregate_function,
+                $.invocation,
+                $.binary_expression,
+                parens($.binary_expression),
+                $.unary_expression,
+                $.array,
+                $.interval,
+            )
+        ),
     ),
 
     binary_expression: $ => choice(
@@ -1781,7 +1784,21 @@ module.exports = grammar({
       ')',
     ),
 
-    list: $ => paren_list($._expression),
+    list: $ => prec(1,
+        paren_list(
+            choice(
+                $.literal,
+                $.field,
+                $.parameter,
+                $.cast,
+                $._aggregate_function,
+                $.invocation,
+                $.implicit_cast,
+                $.array,
+                $.interval,
+            )
+        ),
+    ),
 
     literal: $ => prec(2,
       choice(
@@ -1865,6 +1882,14 @@ function comma_list(field, requireFirst) {
       ),
     ),
   );
+}
+
+function parens(field) {
+    return seq(
+        '(',
+        field,
+        ')'
+    )
 }
 
 function paren_list(field, requireFirst) {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8538,74 +8538,95 @@
       "type": "PREC",
       "value": 1,
       "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "literal"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "field"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "parameter"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "list"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "case"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "window_function"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "subquery"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "cast"
-          },
-          {
-            "type": "ALIAS",
-            "content": {
+        "type": "PREC_LEFT",
+        "value": 0,
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "SYMBOL",
-              "name": "implicit_cast"
+              "name": "literal"
             },
-            "named": true,
-            "value": "cast"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_aggregate_function"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "invocation"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "binary_expression"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "unary_expression"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "array"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "interval"
-          }
-        ]
+            {
+              "type": "SYMBOL",
+              "name": "field"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parameter"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "list"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "case"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "window_function"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "subquery"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "cast"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "implicit_cast"
+              },
+              "named": true,
+              "value": "cast"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_aggregate_function"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "invocation"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "binary_expression"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "binary_expression"
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "unary_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "array"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "interval"
+            }
+          ]
+        }
       }
     },
     "binary_expression": {
@@ -9490,50 +9511,128 @@
       ]
     },
     "list": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": ","
+                        "type": "SYMBOL",
+                        "name": "literal"
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "_expression"
+                        "name": "field"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "parameter"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "cast"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_aggregate_function"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "invocation"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "implicit_cast"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "array"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "interval"
                       }
                     ]
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "literal"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "field"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "parameter"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "cast"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "_aggregate_function"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "invocation"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "implicit_cast"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "array"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "interval"
+                            }
+                          ]
+                        }
+                      ]
+                    }
                   }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
-        }
-      ]
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
     },
     "literal": {
       "type": "PREC",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -540,9 +540,17 @@
         ]
       },
       "right": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true
@@ -646,9 +654,17 @@
     "named": true,
     "fields": {
       "left": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true
@@ -814,9 +830,17 @@
         ]
       },
       "right": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true
@@ -991,9 +1015,17 @@
         ]
       },
       "parameter": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true
@@ -1778,9 +1810,17 @@
         ]
       },
       "parameter": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "all_fields",
             "named": true
@@ -2853,9 +2893,17 @@
         ]
       },
       "parameter": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "all_fields",
             "named": true
@@ -2950,6 +2998,225 @@
     "type": "identifier",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "implicit_cast",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "array",
+          "named": true
+        },
+        {
+          "type": "bigint",
+          "named": true
+        },
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
+          "type": "char",
+          "named": true
+        },
+        {
+          "type": "count",
+          "named": true
+        },
+        {
+          "type": "decimal",
+          "named": true
+        },
+        {
+          "type": "double",
+          "named": true
+        },
+        {
+          "type": "field",
+          "named": true
+        },
+        {
+          "type": "float",
+          "named": true
+        },
+        {
+          "type": "group_concat",
+          "named": true
+        },
+        {
+          "type": "int",
+          "named": true
+        },
+        {
+          "type": "interval",
+          "named": true
+        },
+        {
+          "type": "invocation",
+          "named": true
+        },
+        {
+          "type": "keyword_bigserial",
+          "named": true
+        },
+        {
+          "type": "keyword_boolean",
+          "named": true
+        },
+        {
+          "type": "keyword_box2d",
+          "named": true
+        },
+        {
+          "type": "keyword_box3d",
+          "named": true
+        },
+        {
+          "type": "keyword_bytea",
+          "named": true
+        },
+        {
+          "type": "keyword_date",
+          "named": true
+        },
+        {
+          "type": "keyword_datetime",
+          "named": true
+        },
+        {
+          "type": "keyword_geography",
+          "named": true
+        },
+        {
+          "type": "keyword_geometry",
+          "named": true
+        },
+        {
+          "type": "keyword_interval",
+          "named": true
+        },
+        {
+          "type": "keyword_json",
+          "named": true
+        },
+        {
+          "type": "keyword_jsonb",
+          "named": true
+        },
+        {
+          "type": "keyword_money",
+          "named": true
+        },
+        {
+          "type": "keyword_name",
+          "named": true
+        },
+        {
+          "type": "keyword_oid",
+          "named": true
+        },
+        {
+          "type": "keyword_regclass",
+          "named": true
+        },
+        {
+          "type": "keyword_regnamespace",
+          "named": true
+        },
+        {
+          "type": "keyword_regproc",
+          "named": true
+        },
+        {
+          "type": "keyword_regtype",
+          "named": true
+        },
+        {
+          "type": "keyword_serial",
+          "named": true
+        },
+        {
+          "type": "keyword_smallserial",
+          "named": true
+        },
+        {
+          "type": "keyword_text",
+          "named": true
+        },
+        {
+          "type": "keyword_timestamp",
+          "named": true
+        },
+        {
+          "type": "keyword_timestamptz",
+          "named": true
+        },
+        {
+          "type": "keyword_uuid",
+          "named": true
+        },
+        {
+          "type": "keyword_xml",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "literal",
+          "named": true
+        },
+        {
+          "type": "mediumint",
+          "named": true
+        },
+        {
+          "type": "numeric",
+          "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "smallint",
+          "named": true
+        },
+        {
+          "type": "subquery",
+          "named": true
+        },
+        {
+          "type": "tinyint",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "varchar",
+          "named": true
+        },
+        {
+          "type": "window_function",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "index_hint",
@@ -3141,6 +3408,14 @@
         "required": false,
         "types": [
           {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
             "type": "array",
             "named": true
           },
@@ -3228,9 +3503,17 @@
     "named": true,
     "fields": {
       "predicate": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true
@@ -3587,14 +3870,6 @@
           "named": true
         },
         {
-          "type": "binary_expression",
-          "named": true
-        },
-        {
-          "type": "case",
-          "named": true
-        },
-        {
           "type": "cast",
           "named": true
         },
@@ -3615,6 +3890,10 @@
           "named": true
         },
         {
+          "type": "implicit_cast",
+          "named": true
+        },
+        {
           "type": "interval",
           "named": true
         },
@@ -3623,27 +3902,11 @@
           "named": true
         },
         {
-          "type": "list",
-          "named": true
-        },
-        {
           "type": "literal",
           "named": true
         },
         {
           "type": "parameter",
-          "named": true
-        },
-        {
-          "type": "subquery",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "window_function",
           "named": true
         }
       ]
@@ -4870,9 +5133,17 @@
         ]
       },
       "value": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true
@@ -5017,9 +5288,17 @@
     "named": true,
     "fields": {
       "operand": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true
@@ -5191,9 +5470,17 @@
     "named": true,
     "fields": {
       "predicate": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
           {
             "type": "array",
             "named": true


### PR DESCRIPTION
This is attempt to fix #106 

@DerekStride @dmfay I am unsure if we want to make the parser less permissive, since the main goal is syntax highlighting and not linting. 
However, I have create a function that just wraps parenthesis around the node and modified the `$.list` node to only accept specific nodes instead of `$._expression`. 

Not sure if I handled all cases in line 1787 and following. Since the testing suit only checks on the happy path (there is not "should fail"), I left out the tests.

(Maybe it is worth thinking about refactoring the usage of `$._expression` as well, since it is used everywhere and might not be fitting is some cases.)