### PR TITLE
Add NOT `<>` expression to grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1732,6 +1732,7 @@ module.exports = grammar({
         ['!=', 'binary_relation'],
         ['>=', 'binary_relation'],
         ['>', 'binary_relation'],
+        ['<>', 'binary_relation'],
         [$.keyword_is, 'binary_is'],
         [$.is_not, 'binary_is'],
         [$.keyword_in, 'binary_in'],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9042,6 +9042,39 @@
         },
         {
           "type": "PREC_LEFT",
+          "value": "binary_relation",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "STRING",
+                  "value": "<>"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
           "value": "binary_is",
           "content": {
             "type": "SEQ",
@@ -9810,3 +9843,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -748,6 +748,10 @@
             "named": false
           },
           {
+            "type": "<>",
+            "named": false
+          },
+          {
             "type": "=",
             "named": false
           },
@@ -5482,6 +5486,10 @@
   },
   {
     "type": "<=",
+    "named": false
+  },
+  {
+    "type": "<>",
     "named": false
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -538,3 +538,34 @@ WHERE
               (keyword_similar)
               (keyword_to))
             right: (literal)))))))
+
+================================================================================
+NOT EQUAL <> OPERATOR
+================================================================================
+
+SELECT
+    *
+FROM
+    a
+WHERE
+    a <> '%a'
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (where
+        (keyword_where)
+        predicate: (binary_expression
+          left: (field
+            name: (identifier))
+          right: (literal))))))


### PR DESCRIPTION
The parser was not setup to handle `<>` causing an error when trying to parse SQL queries containing it. 

This change simply adds `<>` to the list of valid expressions, and tests it accordingly. 

Note: since <> is a literal string, it isn't considered a `named node` and won't appear in the tests. This is consistent with operators such as `<=`.