### PR TITLE
feat: add `binary` and `string` datatypes for hive

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -230,6 +230,7 @@ module.exports = grammar({
 
     keyword_boolean: _ => make_keyword("boolean"),
     keyword_bit: _ => make_keyword("bit"),
+    keyword_binary: _ => make_keyword("binary"),
 
     keyword_smallserial: _ => choice(make_keyword("smallserial"),make_keyword("serial2")),
     keyword_serial: _ => choice(make_keyword("serial"),make_keyword("serial4")),
@@ -258,6 +259,7 @@ module.exports = grammar({
       )
     ),
     keyword_text: _ => make_keyword("text"),
+    keyword_string: _ => make_keyword("string"),
     keyword_uuid: _ => make_keyword("uuid"),
 
     keyword_json: _ => make_keyword("json"),
@@ -308,6 +310,7 @@ module.exports = grammar({
     _type: $ => choice(
       $.keyword_boolean,
       $.bit,
+      $.keyword_binary,
 
       $.keyword_smallserial,
       $.keyword_serial,
@@ -327,6 +330,8 @@ module.exports = grammar({
 
       $.char,
       $.varchar,
+      $.numeric,
+      $.keyword_string,
       $.keyword_text,
 
       $.keyword_uuid,
@@ -347,10 +352,6 @@ module.exports = grammar({
       $.keyword_geography,
       $.keyword_box2d,
       $.keyword_box3d,
-
-      $.char,
-      $.varchar,
-      $.numeric,
 
       $.keyword_oid,
       $.keyword_name,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -962,6 +962,10 @@
       "type": "PATTERN",
       "value": "[bB][iI][tT]"
     },
+    "keyword_binary": {
+      "type": "PATTERN",
+      "value": "[bB][iI][nN][aA][rR][yY]"
+    },
     "keyword_smallserial": {
       "type": "CHOICE",
       "members": [
@@ -1150,6 +1154,10 @@
       "type": "PATTERN",
       "value": "[tT][eE][xX][tT]"
     },
+    "keyword_string": {
+      "type": "PATTERN",
+      "value": "[sS][tT][rR][iI][nN][gG]"
+    },
     "keyword_uuid": {
       "type": "PATTERN",
       "value": "[uU][uU][iI][dD]"
@@ -1307,6 +1315,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "keyword_binary"
+        },
+        {
+          "type": "SYMBOL",
           "name": "keyword_smallserial"
         },
         {
@@ -1367,6 +1379,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "numeric"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_string"
+        },
+        {
+          "type": "SYMBOL",
           "name": "keyword_text"
         },
         {
@@ -1424,18 +1444,6 @@
         {
           "type": "SYMBOL",
           "name": "keyword_box3d"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "char"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "varchar"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "numeric"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -115,6 +115,10 @@
             "named": true
           },
           {
+            "type": "keyword_binary",
+            "named": true
+          },
+          {
             "type": "keyword_boolean",
             "named": true
           },
@@ -192,6 +196,10 @@
           },
           {
             "type": "keyword_smallserial",
+            "named": true
+          },
+          {
+            "type": "keyword_string",
             "named": true
           },
           {
@@ -1172,6 +1180,10 @@
           "named": true
         },
         {
+          "type": "keyword_binary",
+          "named": true
+        },
+        {
           "type": "keyword_boolean",
           "named": true
         },
@@ -1249,6 +1261,10 @@
         },
         {
           "type": "keyword_smallserial",
+          "named": true
+        },
+        {
+          "type": "keyword_string",
           "named": true
         },
         {
@@ -1490,6 +1506,10 @@
             "named": true
           },
           {
+            "type": "keyword_binary",
+            "named": true
+          },
+          {
             "type": "keyword_boolean",
             "named": true
           },
@@ -1567,6 +1587,10 @@
           },
           {
             "type": "keyword_smallserial",
+            "named": true
+          },
+          {
+            "type": "keyword_string",
             "named": true
           },
           {
@@ -5728,6 +5752,10 @@
     "named": true
   },
   {
+    "type": "keyword_binary",
+    "named": true
+  },
+  {
     "type": "keyword_bit",
     "named": true
   },
@@ -6273,6 +6301,10 @@
   },
   {
     "type": "keyword_stored",
+    "named": true
+  },
+  {
+    "type": "keyword_string",
     "named": true
   },
   {

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -1125,7 +1125,8 @@ SELECT * FROM _cte
 Create hive table
 ================================================================================
 
-CREATE EXTERNAL TABLE tab (col int)
+CREATE EXTERNAL TABLE tab
+(col int, col2 string, col3 binary)
 PARTITIONED BY (col int)
 SORT BY (col)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY ';' ESCAPED BY '"'
@@ -1148,7 +1149,13 @@ CACHED IN 'pool1' WITH REPLICATION = 2
         (column_definition
           name: (identifier)
           type: (int
-            (keyword_int))))
+            (keyword_int)))
+        (column_definition
+          name: (identifier)
+          type: (keyword_string))
+        (column_definition
+          name: (identifier)
+          type: (keyword_binary)))
       (table_partition
         (keyword_partitioned)
         (keyword_by)


### PR DESCRIPTION
Adds datatypes `string` and `binary` for hive.

`char`, `varchar` and `numeric` where specified twice.