### PR TITLE
feat: add `default_timestamp` option

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -173,6 +173,7 @@ module.exports = grammar({
     keyword_recursive: _ => make_keyword("recursive"),
     keyword_cascaded: _ => make_keyword("cascaded"),
     keyword_local: _ => make_keyword("local"),
+    keyword_current_timestamp: _ => make_keyword("current_timestamp"),
 
     // Hive Keywords
     keyword_external: _ => make_keyword("external"),
@@ -1251,6 +1252,7 @@ module.exports = grammar({
         $.unary_expression,
         $.array,
         $.invocation,
+        $.keyword_current_timestamp,
         alias($.implicit_cast, $.cast),
     ),
 

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -785,6 +785,7 @@ CREATE TABLE type_test (
   a_timestamp TIMESTAMP,
   a_verbose_timestamp TIMESTAMP WITHOUT TIME ZONE,
   a_tstz TIMESTAMPTZ,
+  a_date_with_default_ts DATETIME DEFAULT CURRENT_TIMESTAMP,
   a_verbose_tstz TIMESTAMP WITH TIME ZONE,
   a_geometry GEOMETRY,
   a_geography GEOGRAPHY,
@@ -938,6 +939,11 @@ CREATE TABLE type_test (
         (column_definition
           name: (identifier)
           type: (keyword_timestamptz))
+        (column_definition
+          name: (identifier)
+          type: (keyword_datetime)
+          (keyword_default)
+          (keyword_current_timestamp))
         (column_definition
           name: (identifier)
           type: (keyword_timestamptz))


### PR DESCRIPTION
fixes #122 

I am not sure if adding the new keyword `current_timestamp` directly to the option of `_inner_default_expression` is the best way. However it does not fit into one of the others options that are already there.