### PR TITLE
fix: `check option` as extra keyword nodes (for better highlighting)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -174,6 +174,8 @@ module.exports = grammar({
     keyword_cascaded: _ => make_keyword("cascaded"),
     keyword_local: _ => make_keyword("local"),
     keyword_current_timestamp: _ => make_keyword("current_timestamp"),
+    keyword_check: _ => make_keyword("check"),
+    keyword_option: _ => make_keyword("option"),
 
     // Hive Keywords
     keyword_external: _ => make_keyword("external"),
@@ -226,7 +228,7 @@ module.exports = grammar({
     _exclude_group: $ => seq($.keyword_exclude, $.keyword_group),
     _exclude_no_others: $ => seq($.keyword_exclude, $.keyword_no, $.keyword_others),
     _exclude_ties: $ => seq($.keyword_exclude, $.keyword_ties),
-    _check_option: $ => seq(make_keyword("check"), make_keyword("option")),
+    _check_option: $ => seq($.keyword_check, $.keyword_option),
     direction: $ => choice($.keyword_desc, $.keyword_asc),
 
     // Types

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -652,7 +652,9 @@ CREATE VIEW foo AS SELECT 1 WITH CASCADED CHECK OPTION;
         (select_expression
           (term
             (literal))))
-      (keyword_with)))
+      (keyword_with)
+      (keyword_check)
+      (keyword_option)))
   (statement
     (create_view
       (keyword_create)
@@ -666,7 +668,9 @@ CREATE VIEW foo AS SELECT 1 WITH CASCADED CHECK OPTION;
           (term
             (literal))))
       (keyword_with)
-      (keyword_local)))
+      (keyword_local)
+      (keyword_check)
+      (keyword_option)))
   (statement
     (create_view
       (keyword_create)
@@ -680,7 +684,9 @@ CREATE VIEW foo AS SELECT 1 WITH CASCADED CHECK OPTION;
           (term
             (literal))))
       (keyword_with)
-      (keyword_cascaded))))
+      (keyword_cascaded)
+      (keyword_check)
+      (keyword_option))))
 
 ================================================================================
 Create matview


### PR DESCRIPTION
`check option` should be an extra node to allow to query it for highlighting

See https://github.com/nvim-treesitter/nvim-treesitter/pull/4541