### PR TITLE
Add support for parenthesized expressions & EXISTS subquery

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -125,6 +125,8 @@ module.exports = grammar({
     keyword_unlogged: _ => make_keyword("unlogged"),
     keyword_union: _ => make_keyword("union"),
     keyword_all: _ => make_keyword("all"),
+    keyword_any: _ => make_keyword("any"),
+    keyword_some: _ => make_keyword("some"),
     keyword_except: _ => make_keyword("except"),
     keyword_intersect: _ => make_keyword("intersect"),
     keyword_returning: _ => make_keyword("returning"),
@@ -1867,6 +1869,9 @@ module.exports = grammar({
       ...[
         [$.keyword_not, 'unary_not'],
         [$.bang, 'unary_not'],
+        [$.keyword_any, 'unary_not'],
+        [$.keyword_some, 'unary_not'],
+        [$.keyword_all, 'unary_not'],
       ].map(([operator, precedence]) =>
         prec.left(precedence, seq(
           field('operator', operator),

--- a/grammar.js
+++ b/grammar.js
@@ -1797,6 +1797,7 @@ module.exports = grammar({
         $.array,
         $.interval,
         $.between_expression,
+        seq("(", $._expression, ")"),
       )
     ),
 
@@ -1818,7 +1819,6 @@ module.exports = grammar({
         ['<>', 'binary_relation'],
         [$.keyword_is, 'binary_is'],
         [$.is_not, 'binary_is'],
-        [$.keyword_in, 'binary_in'],
         [$.keyword_like, 'pattern_matching'],
         [$.not_like, 'pattern_matching'],
         [$.similar_to, 'pattern_matching'],
@@ -1844,6 +1844,11 @@ module.exports = grammar({
           field('right', $._expression)
         ))
       ),
+      prec.left('binary_in', seq(
+        field('left', $._expression),
+        field('operator', $.keyword_in),
+        field('right', $.list)
+      )),
     ),
 
     unary_expression: $ => choice(

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -244,6 +244,43 @@ GROUP BY some_field;
           (identifier))))))
 
 ================================================================================
+Unary ANY, ALL, SOME
+================================================================================
+
+SELECT *
+FROM foo
+WHERE id = ANY (
+  SELECT 1
+)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (where
+        (keyword_where)
+        predicate: (binary_expression
+          left: (field
+            name: (identifier))
+          right: (unary_expression
+            operator: (keyword_any)
+            operand: (subquery
+              (select
+                (keyword_select)
+                (select_expression
+                  (term
+                    value: (literal)))))))))))
+
+================================================================================
 In with subquery
 ================================================================================
 

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -242,3 +242,115 @@ GROUP BY some_field;
         (keyword_by)
         (field
           (identifier))))))
+
+================================================================================
+In with subquery
+================================================================================
+
+SELECT *
+FROM foo
+WHERE id IN (
+  SELECT 1
+  FROM bar;
+)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (where
+        (keyword_where)
+        predicate: (binary_expression
+          left: (field
+            name: (identifier))
+          operator: (keyword_in)
+          right: (subquery
+            (select
+              (keyword_select)
+              (select_expression
+                (term
+                  value: (literal))))
+            (from
+              (keyword_from)
+              (relation
+                (table_reference
+                  name: (identifier))))))))))
+
+================================================================================
+exists & not exists
+================================================================================
+
+SELECT *
+FROM foo
+WHERE (
+  NOT EXISTS (
+    SELECT 1
+    FROM bar
+    WHERE 0;
+  ) OR EXISTS (
+    SELECT 1
+    FROM baz
+    WHERE 1;
+  )
+)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (where
+        (keyword_where)
+        predicate: (binary_expression
+          left: (unary_expression
+            operator: (keyword_not)
+            operand: (exists
+              (keyword_exists)
+              (subquery
+                (select
+                  (keyword_select)
+                  (select_expression
+                    (term
+                      value: (literal))))
+                (from
+                  (keyword_from)
+                  (relation
+                    (table_reference
+                      name: (identifier)))
+                  (where
+                    (keyword_where)
+                    predicate: (literal))))))
+          operator: (keyword_or)
+          right: (exists
+            (keyword_exists)
+            (subquery
+              (select
+                (keyword_select)
+                (select_expression
+                  (term
+                    value: (literal))))
+              (from
+                (keyword_from)
+                (relation
+                  (table_reference
+                    name: (identifier)))
+                (where
+                  (keyword_where)
+                  predicate: (literal))))))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -673,9 +673,8 @@ FROM my_table;
       (keyword_distinct)
       (select_expression
         (term
-          value: (list
-            (field
-              name: (identifier))))))
+          value: (field
+            name: (identifier)))))
     (from
       (keyword_from)
       (relation
@@ -722,9 +721,8 @@ FROM my_table;
           value: (count
             name: (keyword_count)
             (keyword_distinct)
-            parameter: (list
-              (field
-                name: (identifier)))))))
+            parameter: (field
+              name: (identifier))))))
     (from
       (keyword_from)
       (relation
@@ -2402,3 +2400,38 @@ where a not between 1 and 3
           (literal)
           (keyword_and)
           (literal))))))
+
+================================================================================
+parameterized expressions
+================================================================================
+
+SELECT 1
+FROM foo
+WHERE (foo OR bar) AND baz
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (literal))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          name: (identifier)))
+      (where
+        (keyword_where)
+        predicate: (binary_expression
+          left: (binary_expression
+            left: (field
+              name: (identifier))
+            operator: (keyword_or)
+            right: (field
+              name: (identifier)))
+          operator: (keyword_and)
+          right: (field
+            name: (identifier)))))))


### PR DESCRIPTION
## What

There's three changes being made in this PR, each are contained to individual commits.
1. Support for parenthesized expression. e.g. wrapping expressions in `(` & `)` to group them.
2. Support for the [`EXISTS`](https://dev.mysql.com/doc/refman/8.0/en/exists-and-not-exists-subqueries.html) expression.
    - Includes subquery support for `IN`
    - Excludes `NOT IN`, there was conflicts with precedence that I want to sort out separately.
3. Support for [`ANY`, `SOME`, & `ALL`](https://www.postgresql.org/docs/current/functions-subquery.html)