### PR TITLE
fix `frame_definition` of window functions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1511,12 +1511,26 @@ module.exports = grammar({
             $.keyword_preceding,
           ),
           seq(
-              $._expression,
+              field("start",
+                choice(
+                  $.identifier,
+                  $.binary_expression,
+                  alias($._literal_string, $.literal),
+                  alias($._integer, $.literal)
+                )
+              ),
               $.keyword_preceding,
           ),
           $._current_row,
           seq(
-              $._expression,
+              field("end",
+                choice(
+                  $.identifier,
+                  $.binary_expression,
+                  alias($._literal_string, $.literal),
+                  alias($._integer, $.literal)
+                )
+              ),
               $.keyword_following,
           ),
           seq(
@@ -1533,23 +1547,20 @@ module.exports = grammar({
             $.keyword_groups,
         ),
 
-        optional(
-            choice(
-                seq(
-                    $.keyword_between,
+        choice(
+            seq(
+                $.keyword_between,
+                $.frame_definition,
+                optional(
+                  seq(
+                    $.keyword_and,
                     $.frame_definition,
-                    optional(
-                      seq(
-                        $.keyword_and,
-                        $.frame_definition,
-                      )
-                    )
-                ),
-                seq(
-                    $.frame_definition,
-                    // $.frame_definition,
+                  )
                 )
             ),
+            seq(
+                $.frame_definition,
+            )
         ),
         optional(
             choice(

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -431,7 +431,7 @@ FROM
               (window_frame
                 (keyword_range)
                 (frame_definition
-                  (binary_expression
+                  start: (binary_expression
                     left: (field
                       name: (identifier))
                     right: (literal))
@@ -500,11 +500,11 @@ FROM
                 (keyword_rows)
                 (keyword_between)
                 (frame_definition
-                  (literal)
+                  start: (literal)
                   (keyword_preceding))
                 (keyword_and)
                 (frame_definition
-                  (literal)
+                  end: (literal)
                   (keyword_following))
                 (keyword_exclude)
                 (keyword_current)


### PR DESCRIPTION
This PR fixes `frame_definitions` of window functions

previously, we could have frame definitions with the `between` keyword and with a `start` and `end` definition. This is not necessary. 
See 
https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS under `frame_clause`

`start` and `end` can now also be an `$._expression`