### PR TITLE
add support for mysql comment keyword in column definition

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1236,6 +1236,11 @@ module.exports = grammar({
       repeat($._column_constraint),
     ),
 
+    _column_comment: $ => seq(
+      $.keyword_comment,
+      alias($._literal_string, $.literal)
+    ),
+
     _column_constraint: $ => choice(
         choice(
             $.keyword_null,
@@ -1245,6 +1250,7 @@ module.exports = grammar({
         $._primary_key,
         $.keyword_auto_increment,
         $.direction,
+        $._column_comment,
     ),
 
     _default_expression: $ => seq(

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -143,6 +143,8 @@ CREATE TABLE my_table (
   created_date DATE NOT NULL,
   random FLOAT DEFAULT RAND(),
   random TEXT DEFAULT 'test',
+  with_comment TEXT COMMENT 'this column has a comment',
+  with_comment_and_constraint TEXT DEFAULT 'test' COMMENT 'this column also has a comment',
   KEY `idx` (`host`, `created_date`)
 );
 
@@ -179,6 +181,18 @@ CREATE TABLE my_table (
           name: (identifier)
           type: (keyword_text)
           (keyword_default)
+          (literal))
+        (column_definition
+          name: (identifier)
+          type: (keyword_text)
+          (keyword_comment)
+          (literal))
+        (column_definition
+          name: (identifier)
+          type: (keyword_text)
+          (keyword_default)
+          (literal)
+          (keyword_comment)
           (literal))
         (constraints
           (constraint


### PR DESCRIPTION
adds support for the MySQL COMMENT keyword in column definitions: https://dev.mysql.com/doc/refman/8.0/en/create-table.html

![Screenshot 2023-04-03 at 3 11 51 PM](https://user-images.githubusercontent.com/5440884/229628672-68a24824-ecf9-4e88-94f7-1a9098611b67.png)
