### PR TITLE
allow count in window functions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1645,7 +1645,10 @@ module.exports = grammar({
     ),
 
     window_function: $ => seq(
-        $.invocation,
+        choice(
+          $.invocation,
+          $.count,
+        ),
         $.keyword_over,
         choice(
             $.identifier,

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -686,3 +686,39 @@ FROM
       (relation
         (table_reference
           (identifier))))))
+
+================================================================================
+Window function with empty count as aggregation
+================================================================================
+
+SELECT
+  count(*) OVER (PARTITION BY c) AS w1
+FROM tab1
+;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (window_function
+            (count
+              (keyword_count)
+              (all_fields))
+            (keyword_over)
+            (window_specification
+              (partition_by
+                (keyword_partition)
+                (keyword_by)
+                (field
+                  (identifier)))))
+          (keyword_as)
+          (identifier))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier))))))


### PR DESCRIPTION
* adds `count` as an option for the aggregation in window functions

@DerekStride a general question regarding the `count` node. For other functions we have the `invocation`. Why do we have this separation? 
In Impala the count in window function can also be empty (haven't checked other dialects) like:
`count() over (partition by col)`

Do you think we should rethink how we handle `invocations`. Maybe a named node for all possibile functions (`now`, `avg`, `sum`, `date_trunc`... <endless list>)