### PR TITLE
feat: create function

### DIFF
--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -520,7 +520,6 @@ CREATE TABLE my_table (
             (keyword_null))
           (direction
             (keyword_asc))))
-      (table_options
         (table_option
           name: (keyword_engine)
           value: (identifier))
@@ -531,7 +530,7 @@ CREATE TABLE my_table (
           value: (identifier))
         (table_option
           name: (identifier)
-          value: (identifier))))))
+          value: (identifier)))))
 
 ================================================================================
 Create view
@@ -1107,7 +1106,6 @@ CREATE TABLE some_table(
                 name: (identifier))
               (column
                 name: (identifier))))))
-      (table_options
         (table_option
           (keyword_default)
           (keyword_character)
@@ -1118,7 +1116,7 @@ CREATE TABLE some_table(
           (identifier))
         (table_option
           name: (keyword_engine)
-          value: (identifier))))))
+          value: (identifier)))))
 
 ================================================================================
 Create table as select

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -414,7 +414,7 @@ return 1;
    (identifier)
    (keyword_returns)
    (int (keyword_int))
-   (function_language)
+   (function_language (keyword_sql))
    (function_body
     (keyword_return)
     (literal)))))
@@ -449,7 +449,7 @@ return 1;
      (keyword_text)))
    (keyword_returns)
    (int (keyword_int))
-   (function_language)
+   (function_language (keyword_sql))
    (function_body
     (keyword_return)
     (literal)))))
@@ -459,13 +459,14 @@ Function details
 ================================================================================
 
 create or replace function public.fn()
- returns int
- language sql
- immutable
- parallel safe
- strict
- cost 100
- rows 1
+  returns int
+  language sql
+  immutable
+  parallel safe
+  leakproof
+  strict
+  cost 100
+  rows 1
 return 1;
 
 --------------------------------------------------------------------------------
@@ -481,23 +482,140 @@ return 1;
    (identifier)
    (keyword_returns)
    (int (keyword_int))
-   (function_language)
-   (function_volatility)
-   (function_safety)
-   (function_strictness)
-   (function_cost)
-   (function_rows)
+   (function_language (keyword_sql))
+   (function_volatility (keyword_immutable))
+   (function_safety (keyword_parallel) (keyword_safe))
+   (function_leakproof (keyword_leakproof))
+   (function_strictness (keyword_strict))
+   (function_cost (keyword_cost))
+   (function_rows (keyword_rows))
    (function_body
     (keyword_return)
     (literal)))))
+
+================================================================================
+Function details, specified after string body
+================================================================================
+
+create or replace function public.fn()
+  returns int
+  as $$select 1$$
+  language sql
+  volatile
+  parallel restricted
+  not leakproof
+  returns null on null input
+  cost 100
+  rows 1;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   schema: (identifier)
+   name: (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_body
+    (keyword_as)
+    (dollar_quote)
+    (statement
+     (select
+      (keyword_select)
+      (select_expression
+       (term
+        value: (literal)))))
+    (dollar_quote))
+   (function_language (keyword_sql))
+   (function_volatility (keyword_volatile))
+  (function_safety (keyword_parallel) (keyword_restricted))
+  (function_leakproof (keyword_not) (keyword_leakproof))
+  (function_strictness (keyword_returns) (keyword_null) (keyword_on) (keyword_null) (keyword_input))
+  (function_cost (keyword_cost))
+(function_rows (keyword_rows)))))
+
+================================================================================
+With a string body
+================================================================================
+
+create or replace function public.fn()
+  returns int
+  language sql
+as 'select 1;';
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language (keyword_sql))
+   (function_body
+    (keyword_as)
+    (statement
+     (select
+      (keyword_select)
+      (select_expression
+       (term
+        (literal)))))))))
+
+================================================================================
+Precedence between string body and `create table` with string options
+================================================================================
+
+create or replace function public.fn()
+  returns int
+  language sql
+as 'create table x (id int) row_format=dynamic';
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language (keyword_sql))
+   (function_body
+    (keyword_as)
+    (statement
+     (create_table
+      (keyword_create)
+      (keyword_table)
+      (table_reference
+       (identifier))
+      (column_definitions
+       (column_definition
+        (identifier)
+        (int
+         (keyword_int))))
+      (table_option (identifier) (identifier))))))))
 
 ================================================================================
 With `begin atomic`
 ================================================================================
 
 create or replace function public.fn()
- returns int
- language sql
+  returns int
+  language sql
 begin atomic
   return 1;
 end;
@@ -515,7 +633,7 @@ end;
    (identifier)
    (keyword_returns)
    (int (keyword_int))
-   (function_language)
+   (function_language (keyword_sql))
    (function_body
     (keyword_begin)
     (keyword_atomic)
@@ -528,8 +646,8 @@ Dollar quoting a simple PLPGSQL body
 ================================================================================
 
 create or replace function public.fn()
- returns int
- language plpgsql
+  returns int
+  language plpgsql
 as $function$
 begin
   return 1;
@@ -549,7 +667,7 @@ $function$;
    (identifier)
    (keyword_returns)
    (int (keyword_int))
-   (function_language)
+   (function_language (keyword_plpgsql))
    (function_body
     (keyword_as)
     (dollar_quote)
@@ -564,8 +682,8 @@ Variable declarations
 ================================================================================
 
 create or replace function public.fn()
- returns int
- language plpgsql
+  returns int
+  language plpgsql
 as $function$
 declare
   one int;
@@ -589,7 +707,7 @@ $function$;
    (identifier)
    (keyword_returns)
    (int (keyword_int))
-   (function_language)
+   (function_language (keyword_plpgsql))
    (function_body
     (keyword_as)
     (dollar_quote)
@@ -621,8 +739,8 @@ More complex function body
 ================================================================================
 
 create or replace function public.do_stuff()
- returns trigger
- language plpgsql
+  returns trigger
+  language plpgsql
 as $function$
 begin
 
@@ -666,7 +784,7 @@ $function$
    (identifier)
    (keyword_returns)
    (keyword_trigger)
-   (function_language)
+   (function_language (keyword_plpgsql))
    (function_body
     (keyword_as)
     (dollar_quote)

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -391,3 +391,381 @@ WHERE (
                 (where
                   (keyword_where)
                   predicate: (literal))))))))))
+
+================================================================================
+Basic SQL function creation
+================================================================================
+
+create or replace function public.fn()
+ returns int
+ language sql
+return 1;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language)
+   (function_body
+    (keyword_return)
+    (literal)))))
+
+================================================================================
+With arguments
+================================================================================
+
+create or replace function public.fn(one int, two text)
+ returns int
+ language sql
+return 1;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (column_definitions
+    (column_definition
+     (identifier)
+     (int
+      (keyword_int)))
+    (column_definition
+     (identifier)
+     (keyword_text)))
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language)
+   (function_body
+    (keyword_return)
+    (literal)))))
+
+================================================================================
+Function details
+================================================================================
+
+create or replace function public.fn()
+ returns int
+ language sql
+ immutable
+ parallel safe
+ strict
+ cost 100
+ rows 1
+return 1;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language)
+   (function_volatility)
+   (function_safety)
+   (function_strictness)
+   (function_cost)
+   (function_rows)
+   (function_body
+    (keyword_return)
+    (literal)))))
+
+================================================================================
+With `begin atomic`
+================================================================================
+
+create or replace function public.fn()
+ returns int
+ language sql
+begin atomic
+  return 1;
+end;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language)
+   (function_body
+    (keyword_begin)
+    (keyword_atomic)
+    (keyword_return)
+    (literal)
+    (keyword_end)))))
+
+================================================================================
+Dollar quoting a simple PLPGSQL body
+================================================================================
+
+create or replace function public.fn()
+ returns int
+ language plpgsql
+as $function$
+begin
+  return 1;
+end;
+$function$;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language)
+   (function_body
+    (keyword_as)
+    (dollar_quote)
+    (keyword_begin)
+    (keyword_return)
+    (literal)
+    (keyword_end)
+    (dollar_quote)))))
+
+================================================================================
+Variable declarations
+================================================================================
+
+create or replace function public.fn()
+ returns int
+ language plpgsql
+as $function$
+declare
+  one int;
+  two text := (select 'hello');
+  three text := 'world';
+begin
+  return 1;
+end;
+$function$;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (int (keyword_int))
+   (function_language)
+   (function_body
+    (keyword_as)
+    (dollar_quote)
+    (keyword_declare)
+    (function_declaration
+     (identifier)
+     (int (keyword_int)))
+    (function_declaration
+     (identifier)
+     (keyword_text)
+     (statement
+      (select
+       (keyword_select)
+       (select_expression
+        (term
+         (literal))))))
+    (function_declaration
+     (identifier)
+     (keyword_text)
+     (literal))
+    (keyword_begin)
+  (keyword_return)
+  (literal)
+  (keyword_end)
+(dollar_quote)))))
+
+================================================================================
+More complex function body
+================================================================================
+
+create or replace function public.do_stuff()
+ returns trigger
+ language plpgsql
+as $function$
+begin
+
+  -- comment!
+  with knn as (
+    select
+      h.alpha,
+      -- TODO factor in distance
+      avg(e.beta) as e_beta
+    from htable h
+    cross join lateral (
+      select
+        id,
+        gamma,
+        delta,
+        centroid
+      from ftable
+      limit 3
+    ) as e
+    group by h.alpha
+  )
+  update htable set epsilon = epsilon + e_beta
+  from knn
+  where knn.alpha = htable.alpha;
+
+  return new;
+
+end;
+$function$
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (create_function
+   (keyword_create)
+   (keyword_or)
+   (keyword_replace)
+   (keyword_function)
+   (identifier)
+   (identifier)
+   (keyword_returns)
+   (keyword_trigger)
+   (function_language)
+   (function_body
+    (keyword_as)
+    (dollar_quote)
+    (keyword_begin)
+    (comment)
+    (statement
+     (keyword_with)
+     (cte
+      (identifier)
+      (keyword_as)
+      (statement
+       (select
+        (keyword_select)
+        (select_expression
+         (term
+          (field
+           (identifier)
+           (identifier)))
+         (comment)
+         (term
+          (invocation
+           (identifier)
+           (field
+            (identifier)
+            (identifier)))
+          (keyword_as)
+          (identifier))))
+       (from
+        (keyword_from)
+        (relation
+         (table_reference
+          (identifier))
+         (identifier))
+        (lateral_cross_join
+         (keyword_cross)
+         (keyword_join)
+         (keyword_lateral)
+         (subquery
+          (select
+           (keyword_select)
+           (select_expression
+            (term
+             (field
+              (identifier)))
+            (term
+             (field
+              (identifier)))
+            (term
+             (field
+              (identifier)))
+            (term
+             (field
+              (identifier)))))
+          (from
+           (keyword_from)
+           (relation
+            (table_reference
+             (identifier)))
+           (limit
+            (keyword_limit)
+            (literal))))
+  (keyword_as)
+(identifier))
+  (group_by
+   (keyword_group)
+   (keyword_by)
+   (field
+    (identifier)
+    (identifier))))))
+  (update
+   (keyword_update)
+   (relation
+    (table_reference
+     (identifier)))
+   (keyword_set)
+   (assignment
+    (field
+     (identifier))
+    (binary_expression
+     (field
+      (identifier))
+     (field
+      (identifier))))
+   (from
+    (keyword_from)
+    (relation
+     (table_reference
+      (identifier)))
+    (where
+     (keyword_where)
+     (binary_expression
+      (field
+       (identifier)
+       (identifier))
+      (field
+       (identifier)
+       (identifier)))))))
+(keyword_return)
+  (field
+   (identifier))
+  (keyword_end)
+(dollar_quote)))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -1235,7 +1235,7 @@ Lateral join subquery
 
 SELECT a.id, b.*
 FROM my_table a
-CROSS JOIN LATERAL (SELECT 1) AS b ON TRUE;
+CROSS JOIN LATERAL (SELECT 1) AS b;
 
 --------------------------------------------------------------------------------
 
@@ -1256,7 +1256,7 @@ CROSS JOIN LATERAL (SELECT 1) AS b ON TRUE;
         (table_reference
           name: (identifier))
         table_alias: (identifier))
-      (lateral_join
+      (lateral_cross_join
         (keyword_cross)
         (keyword_join)
         (keyword_lateral)
@@ -1267,10 +1267,7 @@ CROSS JOIN LATERAL (SELECT 1) AS b ON TRUE;
               (term
                 value: (literal)))))
         (keyword_as)
-        alias: (identifier)
-        (keyword_on)
-        (literal
-          (keyword_true))))))
+        alias: (identifier)))))
 
 ================================================================================
 Multiple joins


### PR DESCRIPTION
not perfect but it's (Postgres-flavored) progress!

@matthias-Q I ran into a conflict between `create function x () as 'select 1'` and `create table y (id int) 'param'='value'`. Setting left precedence on `create table` worked, and I have a test case with a string-bodied function creating a table with options, although non-quoted since quoting _within_ a quote-delimited functino body isn't there yet. I did reorganize table settings under table options since they seem like roughly the same thing, and added Databricks' explicit `options` while trying to get to the bottom of the conflict.

Otherwise:

- lateral cross joins don't take an `on`, so that's fixed
- I did look into adding a custom scanner for tracking dollar quote opening/closing a while back but didn't have much success. I've [pushed that branch](https://github.com/DerekStride/tree-sitter-sql/tree/dmf/dollar-quoting) in case it's a helpful start

This also opens the enormous can of worms that is the question of where we draw the line on procedural control structures from pl/pgsql and friends! I've omitted them here since this is already plenty long.