### PR TITLE
removed `count` in favour of `invocation`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -82,7 +82,6 @@ module.exports = grammar({
     keyword_distinct: _ => make_keyword("distinct"),
     keyword_constraint: _ => make_keyword("constraint"),
     keyword_cast: _ => make_keyword("cast"),
-    keyword_count: _ => make_keyword("count"),
     keyword_group_concat: _ => make_keyword("group_concat"),
     keyword_separator: _ => make_keyword("separator"),
     keyword_max: _ => make_keyword("max"),
@@ -1741,14 +1740,6 @@ module.exports = grammar({
 
     _aggregate_function: $ => choice(
       $.group_concat,
-      $.count,
-    ),
-
-    count: $ => seq(
-      field('name', $.keyword_count),
-      '(',
-      $._aggregate_expression,
-      ')',
     ),
 
     group_concat: $ => seq(
@@ -1767,7 +1758,7 @@ module.exports = grammar({
 
     invocation: $ => seq(
       field('name', $.identifier),
-      paren_list(field('parameter', $._expression)),
+      paren_list(field('parameter', $._select_expression)),
     ),
 
     exists: $ => seq(
@@ -1873,10 +1864,7 @@ module.exports = grammar({
     ),
 
     window_function: $ => seq(
-        choice(
-          $.invocation,
-          $.count,
-        ),
+        $.invocation,
         $.keyword_over,
         choice(
             $.identifier,

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -14,8 +14,9 @@ FROM my_table;
         (term
           value: (invocation
             name: (identifier)
-            parameter: (field
-              name: (identifier))))))
+            parameter: (term
+              value: (field
+                name: (identifier)))))))
     (from
       (keyword_from)
       (relation
@@ -61,31 +62,41 @@ FROM my_table AS t;
         (term
           value: (invocation
             name: (identifier)
-            parameter: (field
-              name: (identifier))
-            parameter: (literal)
-            parameter: (invocation
-              name: (identifier)
-              parameter: (field
-                name: (identifier))
-              parameter: (literal))
-            parameter: (binary_expression
-              left: (binary_expression
-                left: (field
-                  name: (identifier))
-                right: (literal))
-              right: (literal)))
+            parameter: (term
+              value: (field
+                name: (identifier)))
+            parameter: (term
+              value: (literal))
+            parameter: (term
+              value: (invocation
+                name: (identifier)
+                parameter: (term
+                  value: (field
+                    name: (identifier)))
+                parameter: (term
+                  value: (literal))))
+            parameter: (term
+              value: (binary_expression
+                left: (binary_expression
+                  left: (field
+                    name: (identifier))
+                  right: (literal))
+                right: (literal))))
           (keyword_as)
           alias: (identifier))
         (term
           value: (invocation
             name: (identifier)
-            parameter: (field
-              table_alias: (identifier)
-              name: (identifier))
-            parameter: (literal)
-            parameter: (literal)
-            parameter: (literal))
+            parameter: (term
+              value: (field
+                table_alias: (identifier)
+                name: (identifier)))
+            parameter: (term
+              value: (literal))
+            parameter: (term
+              value: (literal))
+            parameter: (term
+              value: (literal)))
           (keyword_as)
           alias: (identifier))
         (term
@@ -120,21 +131,25 @@ select col_has_check(
         (term
           value: (invocation
             name: (identifier)
-            parameter: (cast
-              (literal)
-              (keyword_name))
-            parameter: (cast
-              (literal)
-              (keyword_name))
-            parameter: (array
-              (keyword_array)
-              (cast
-                (literal)
-                (keyword_name))
-              (cast
+            parameter: (term
+              value: (cast
                 (literal)
                 (keyword_name)))
-            parameter: (literal)))))))
+            parameter: (term
+              value: (cast
+                (literal)
+                (keyword_name)))
+            parameter: (term
+              value: (array
+                (keyword_array)
+                (cast
+                  (literal)
+                  (keyword_name))
+                (cast
+                  (literal)
+                  (keyword_name))))
+            parameter: (term
+              value: (literal))))))))
 
 ================================================================================
 Count with postgres style aggregate expression
@@ -151,17 +166,14 @@ FROM table_a;
       (keyword_select)
       (select_expression
         (term
-          value: (count
-            name: (keyword_count)
-            (keyword_distinct)
-            parameter: (field
-              name: (identifier))
-            (order_by
-              (keyword_order)
-              (keyword_by)
-              (order_target
-                (field
-                  name: (identifier))))))))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (field
+                name: (identifier))
+              alias: (identifier))
+            (ERROR
+              (keyword_by))))))
     (from
       (keyword_from)
       (relation
@@ -404,20 +416,22 @@ return 1;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_sql))
-   (function_body
-    (keyword_return)
-    (literal)))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_sql))
+      (function_body
+        (keyword_return)
+        (literal)))))
 
 ================================================================================
 With arguments
@@ -431,28 +445,30 @@ return 1;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (column_definitions
-    (column_definition
-     (identifier)
-     (int
-      (keyword_int)))
-    (column_definition
-     (identifier)
-     (keyword_text)))
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_sql))
-   (function_body
-    (keyword_return)
-    (literal)))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (column_definitions
+        (column_definition
+          (identifier)
+          (int
+            (keyword_int)))
+        (column_definition
+          (identifier)
+          (keyword_text)))
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_sql))
+      (function_body
+        (keyword_return)
+        (literal)))))
 
 ================================================================================
 Function details
@@ -472,26 +488,35 @@ return 1;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_sql))
-   (function_volatility (keyword_immutable))
-   (function_safety (keyword_parallel) (keyword_safe))
-   (function_leakproof (keyword_leakproof))
-   (function_strictness (keyword_strict))
-   (function_cost (keyword_cost))
-   (function_rows (keyword_rows))
-   (function_body
-    (keyword_return)
-    (literal)))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_sql))
+      (function_volatility
+        (keyword_immutable))
+      (function_safety
+        (keyword_parallel)
+        (keyword_safe))
+      (function_leakproof
+        (keyword_leakproof))
+      (function_strictness
+        (keyword_strict))
+      (function_cost
+        (keyword_cost))
+      (function_rows
+        (keyword_rows))
+      (function_body
+        (keyword_return)
+        (literal)))))
 
 ================================================================================
 Function details, specified after string body
@@ -511,33 +536,47 @@ create or replace function public.fn()
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   schema: (identifier)
-   name: (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_body
-    (keyword_as)
-    (dollar_quote)
-    (statement
-     (select
-      (keyword_select)
-      (select_expression
-       (term
-        value: (literal)))))
-    (dollar_quote))
-   (function_language (keyword_sql))
-   (function_volatility (keyword_volatile))
-  (function_safety (keyword_parallel) (keyword_restricted))
-  (function_leakproof (keyword_not) (keyword_leakproof))
-  (function_strictness (keyword_returns) (keyword_null) (keyword_on) (keyword_null) (keyword_input))
-  (function_cost (keyword_cost))
-(function_rows (keyword_rows)))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      schema: (identifier)
+      name: (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_body
+        (keyword_as)
+        (dollar_quote)
+        (statement
+          (select
+            (keyword_select)
+            (select_expression
+              (term
+                value: (literal)))))
+        (dollar_quote))
+      (function_language
+        (keyword_sql))
+      (function_volatility
+        (keyword_volatile))
+      (function_safety
+        (keyword_parallel)
+        (keyword_restricted))
+      (function_leakproof
+        (keyword_not)
+        (keyword_leakproof))
+      (function_strictness
+        (keyword_returns)
+        (keyword_null)
+        (keyword_on)
+        (keyword_null)
+        (keyword_input))
+      (function_cost
+        (keyword_cost))
+      (function_rows
+        (keyword_rows)))))
 
 ================================================================================
 With a string body
@@ -551,25 +590,27 @@ as 'select 1;';
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_sql))
-   (function_body
-    (keyword_as)
-    (statement
-     (select
-      (keyword_select)
-      (select_expression
-       (term
-        (literal)))))))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_sql))
+      (function_body
+        (keyword_as)
+        (statement
+          (select
+            (keyword_select)
+            (select_expression
+              (term
+                (literal)))))))))
 
 ================================================================================
 Precedence between string body and `create table` with string options
@@ -583,31 +624,35 @@ as 'create table x (id int) row_format=dynamic';
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_sql))
-   (function_body
-    (keyword_as)
-    (statement
-     (create_table
+  (statement
+    (create_function
       (keyword_create)
-      (keyword_table)
-      (table_reference
-       (identifier))
-      (column_definitions
-       (column_definition
-        (identifier)
-        (int
-         (keyword_int))))
-      (table_option (identifier) (identifier))))))))
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_sql))
+      (function_body
+        (keyword_as)
+        (statement
+          (create_table
+            (keyword_create)
+            (keyword_table)
+            (table_reference
+              (identifier))
+            (column_definitions
+              (column_definition
+                (identifier)
+                (int
+                  (keyword_int))))
+            (table_option
+              (identifier)
+              (identifier))))))))
 
 ================================================================================
 With `begin atomic`
@@ -623,23 +668,25 @@ end;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_sql))
-   (function_body
-    (keyword_begin)
-    (keyword_atomic)
-    (keyword_return)
-    (literal)
-    (keyword_end)))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_sql))
+      (function_body
+        (keyword_begin)
+        (keyword_atomic)
+        (keyword_return)
+        (literal)
+        (keyword_end)))))
 
 ================================================================================
 Dollar quoting a simple PLPGSQL body
@@ -657,25 +704,27 @@ $function$;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_plpgsql))
-   (function_body
-    (keyword_as)
-    (dollar_quote)
-    (keyword_begin)
-    (keyword_return)
-    (literal)
-    (keyword_end)
-    (dollar_quote)))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_plpgsql))
+      (function_body
+        (keyword_as)
+        (dollar_quote)
+        (keyword_begin)
+        (keyword_return)
+        (literal)
+        (keyword_end)
+        (dollar_quote)))))
 
 ================================================================================
 Variable declarations
@@ -697,42 +746,45 @@ $function$;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (int (keyword_int))
-   (function_language (keyword_plpgsql))
-   (function_body
-    (keyword_as)
-    (dollar_quote)
-    (keyword_declare)
-    (function_declaration
-     (identifier)
-     (int (keyword_int)))
-    (function_declaration
-     (identifier)
-     (keyword_text)
-     (statement
-      (select
-       (keyword_select)
-       (select_expression
-        (term
-         (literal))))))
-    (function_declaration
-     (identifier)
-     (keyword_text)
-     (literal))
-    (keyword_begin)
-  (keyword_return)
-  (literal)
-  (keyword_end)
-(dollar_quote)))))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (identifier)
+      (identifier)
+      (keyword_returns)
+      (int
+        (keyword_int))
+      (function_language
+        (keyword_plpgsql))
+      (function_body
+        (keyword_as)
+        (dollar_quote)
+        (keyword_declare)
+        (function_declaration
+          (identifier)
+          (int
+            (keyword_int)))
+        (function_declaration
+          (identifier)
+          (keyword_text)
+          (statement
+            (select
+              (keyword_select)
+              (select_expression
+                (term
+                  (literal))))))
+        (function_declaration
+          (identifier)
+          (keyword_text)
+          (literal))
+        (keyword_begin)
+        (keyword_return)
+        (literal)
+        (keyword_end)
+        (dollar_quote)))))
 
 ================================================================================
 More complex function body
@@ -774,116 +826,118 @@ $function$
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (create_function
-   (keyword_create)
-   (keyword_or)
-   (keyword_replace)
-   (keyword_function)
-   (identifier)
-   (identifier)
-   (keyword_returns)
-   (keyword_trigger)
-   (function_language (keyword_plpgsql))
-   (function_body
-    (keyword_as)
-    (dollar_quote)
-    (keyword_begin)
-    (comment)
-    (statement
-     (keyword_with)
-     (cte
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
       (identifier)
-      (keyword_as)
-      (statement
-       (select
-        (keyword_select)
-        (select_expression
-         (term
-          (field
-           (identifier)
-           (identifier)))
-         (comment)
-         (term
-          (invocation
-           (identifier)
-           (field
+      (identifier)
+      (keyword_returns)
+      (keyword_trigger)
+      (function_language
+        (keyword_plpgsql))
+      (function_body
+        (keyword_as)
+        (dollar_quote)
+        (keyword_begin)
+        (comment)
+        (statement
+          (keyword_with)
+          (cte
             (identifier)
-            (identifier)))
-          (keyword_as)
-          (identifier))))
-       (from
-        (keyword_from)
-        (relation
-         (table_reference
+            (keyword_as)
+            (statement
+              (select
+                (keyword_select)
+                (select_expression
+                  (term
+                    (field
+                      (identifier)
+                      (identifier)))
+                  (comment)
+                  (term
+                    (invocation
+                      (identifier)
+                      (term
+                        (field
+                          (identifier)
+                          (identifier))))
+                    (keyword_as)
+                    (identifier))))
+              (from
+                (keyword_from)
+                (relation
+                  (table_reference
+                    (identifier))
+                  (identifier))
+                (lateral_cross_join
+                  (keyword_cross)
+                  (keyword_join)
+                  (keyword_lateral)
+                  (subquery
+                    (select
+                      (keyword_select)
+                      (select_expression
+                        (term
+                          (field
+                            (identifier)))
+                        (term
+                          (field
+                            (identifier)))
+                        (term
+                          (field
+                            (identifier)))
+                        (term
+                          (field
+                            (identifier)))))
+                    (from
+                      (keyword_from)
+                      (relation
+                        (table_reference
+                          (identifier)))
+                      (limit
+                        (keyword_limit)
+                        (literal))))
+                  (keyword_as)
+                  (identifier))
+                (group_by
+                  (keyword_group)
+                  (keyword_by)
+                  (field
+                    (identifier)
+                    (identifier))))))
+          (update
+            (keyword_update)
+            (relation
+              (table_reference
+                (identifier)))
+            (keyword_set)
+            (assignment
+              (field
+                (identifier))
+              (binary_expression
+                (field
+                  (identifier))
+                (field
+                  (identifier))))
+            (from
+              (keyword_from)
+              (relation
+                (table_reference
+                  (identifier)))
+              (where
+                (keyword_where)
+                (binary_expression
+                  (field
+                    (identifier)
+                    (identifier))
+                  (field
+                    (identifier)
+                    (identifier)))))))
+        (keyword_return)
+        (field
           (identifier))
-         (identifier))
-        (lateral_cross_join
-         (keyword_cross)
-         (keyword_join)
-         (keyword_lateral)
-         (subquery
-          (select
-           (keyword_select)
-           (select_expression
-            (term
-             (field
-              (identifier)))
-            (term
-             (field
-              (identifier)))
-            (term
-             (field
-              (identifier)))
-            (term
-             (field
-              (identifier)))))
-          (from
-           (keyword_from)
-           (relation
-            (table_reference
-             (identifier)))
-           (limit
-            (keyword_limit)
-            (literal))))
-  (keyword_as)
-(identifier))
-  (group_by
-   (keyword_group)
-   (keyword_by)
-   (field
-    (identifier)
-    (identifier))))))
-  (update
-   (keyword_update)
-   (relation
-    (table_reference
-     (identifier)))
-   (keyword_set)
-   (assignment
-    (field
-     (identifier))
-    (binary_expression
-     (field
-      (identifier))
-     (field
-      (identifier))))
-   (from
-    (keyword_from)
-    (relation
-     (table_reference
-      (identifier)))
-    (where
-     (keyword_where)
-     (binary_expression
-      (field
-       (identifier)
-       (identifier))
-      (field
-       (identifier)
-       (identifier)))))))
-(keyword_return)
-  (field
-   (identifier))
-  (keyword_end)
-(dollar_quote)))))
+        (keyword_end)
+        (dollar_quote)))))

--- a/test/corpus/group_by.txt
+++ b/test/corpus/group_by.txt
@@ -18,10 +18,11 @@ HAVING other_id > 10;
           value: (field
             name: (identifier)))
         (term
-          value: (count
-            name: (keyword_count)
-            parameter: (field
-              name: (identifier))))))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (field
+                name: (identifier)))))))
     (from
       (keyword_from)
       (relation
@@ -57,10 +58,11 @@ HAVING other_id > 10;
           value: (field
             name: (identifier)))
         (term
-          value: (count
-            name: (keyword_count)
-            parameter: (field
-              name: (identifier))))))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (field
+                name: (identifier)))))))
     (from
       (keyword_from)
       (relation
@@ -98,10 +100,11 @@ HAVING other_id > 10;
           value: (field
             name: (identifier)))
         (term
-          value: (count
-            name: (keyword_count)
-            parameter: (field
-              name: (identifier))))))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (field
+                name: (identifier)))))))
     (from
       (keyword_from)
       (relation
@@ -139,10 +142,11 @@ HAVING COUNT(*) = 2;
           value: (field
             name: (identifier)))
         (term
-          value: (count
-            name: (keyword_count)
-            parameter: (field
-              name: (identifier))))))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (field
+                name: (identifier)))))))
     (from
       (keyword_from)
       (relation
@@ -155,7 +159,7 @@ HAVING COUNT(*) = 2;
           name: (identifier))
         (keyword_having)
         (binary_expression
-          left: (count
-            name: (keyword_count)
+          left: (invocation
+            name: (identifier)
             parameter: (all_fields))
           right: (literal))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -377,11 +377,14 @@ FROM my_table m;
         (term
           value: (invocation
             name: (identifier)
-            parameter: (field
-              table_alias: (identifier)
-              name: (identifier))
-            parameter: (literal)
-            parameter: (literal))
+            parameter: (term
+              value: (field
+                table_alias: (identifier)
+                name: (identifier)))
+            parameter: (term
+              value: (literal))
+            parameter: (term
+              value: (literal)))
           (keyword_as)
           alias: (identifier))))
     (from
@@ -412,13 +415,16 @@ FROM my_table m;
         (term
           value: (invocation
             name: (identifier)
-            parameter: (binary_expression
-              left: (field
-                table_alias: (identifier)
-                name: (identifier))
-              right: (literal))
-            parameter: (literal)
-            parameter: (literal))
+            parameter: (term
+              value: (binary_expression
+                left: (field
+                  table_alias: (identifier)
+                  name: (identifier))
+                right: (literal)))
+            parameter: (term
+              value: (literal))
+            parameter: (term
+              value: (literal)))
           alias: (identifier))))
     (from
       (keyword_from)
@@ -466,11 +472,12 @@ FROM my_table;
       (keyword_select)
       (select_expression
         (term
-          value: (count
-            name: (keyword_count)
-            (keyword_distinct)
-            parameter: (field
-              name: (identifier)))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (field
+                name: (identifier))
+              alias: (identifier)))
           (keyword_as)
           alias: (identifier))))
     (from
@@ -718,11 +725,14 @@ FROM my_table;
       (keyword_select)
       (select_expression
         (term
-          value: (count
-            name: (keyword_count)
-            (keyword_distinct)
-            parameter: (field
-              name: (identifier))))))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (invocation
+                name: (identifier)
+                parameter: (term
+                  value: (field
+                    name: (identifier)))))))))
     (from
       (keyword_from)
       (relation
@@ -743,8 +753,8 @@ FROM my_table;
       (keyword_select)
       (select_expression
         (term
-          value: (count
-            name: (keyword_count)
+          value: (invocation
+            name: (identifier)
             parameter: (all_fields)))))
     (from
       (keyword_from)
@@ -766,11 +776,12 @@ FROM my_table;
       (keyword_select)
       (select_expression
         (term
-          value: (count
-            name: (keyword_count)
-            (keyword_distinct)
-            parameter: (field
-              name: (identifier))))))
+          value: (invocation
+            name: (identifier)
+            parameter: (term
+              value: (field
+                name: (identifier))
+              alias: (identifier))))))
     (from
       (keyword_from)
       (relation
@@ -1220,9 +1231,10 @@ JOIN LATERAL unnest(a.arr) AS arr ON TRUE;
         (keyword_lateral)
         (invocation
           name: (identifier)
-          parameter: (field
-            table_alias: (identifier)
-            name: (identifier)))
+          parameter: (term
+            value: (field
+              table_alias: (identifier)
+              name: (identifier))))
         (keyword_as)
         alias: (identifier)
         (keyword_on)

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -29,8 +29,9 @@ FROM tab1;
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -75,8 +76,9 @@ FROM tab1;
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (order_by
@@ -126,8 +128,9 @@ FROM tab1;
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -174,8 +177,9 @@ FROM tab1;
           (window_function
             (invocation
               (identifier)
-              (field
-                (identifier)))
+              (term
+                (field
+                  (identifier))))
             (keyword_over)
             (window_specification))
           (keyword_as)
@@ -210,8 +214,9 @@ FROM tab1;
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -225,8 +230,9 @@ FROM tab1;
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (order_by
@@ -270,8 +276,9 @@ WINDOW window_def AS (PARTITION BY y);
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (identifier)))))
     (from
@@ -316,8 +323,9 @@ WINDOW win AS (ORDER BY d)
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -331,8 +339,9 @@ WINDOW win AS (ORDER BY d)
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (identifier))
           (keyword_as)
@@ -390,8 +399,9 @@ FROM
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -419,8 +429,9 @@ FROM
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -475,8 +486,9 @@ FROM
           value: (window_function
             (invocation
               name: (identifier)
-              parameter: (field
-                name: (identifier)))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -564,8 +576,9 @@ FROM
           (window_function
             (invocation
               (identifier)
-              (field
-                (identifier)))
+              (term
+                (field
+                  (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -613,8 +626,9 @@ FROM
                         (identifier)))))
                 (invocation
                   (identifier)
-                  (field
-                    (identifier)))
+                  (term
+                    (field
+                      (identifier))))
                 (binary_expression
                   (field
                     (identifier))
@@ -673,8 +687,9 @@ FROM
                 (order_target
                   (invocation
                     (identifier)
-                    (field
-                      (identifier))))
+                    (term
+                      (field
+                        (identifier)))))
                 (order_target
                   (binary_expression
                     (field
@@ -705,8 +720,8 @@ FROM tab1
       (select_expression
         (term
           (window_function
-            (count
-              (keyword_count)
+            (invocation
+              (identifier)
               (all_fields))
             (keyword_over)
             (window_specification


### PR DESCRIPTION
This PR removed the `count` node in favor of the more generic `invocation.

I have a question:
We have `_expression`, `term` and `_select_expression` (which is `term` or `all_fields`). I may have forgotten this, but why do we have these? They look almost identical and offer only another layer in the AST hierarchy.

