### PR TITLE
WIP: add multiple alter statements add once (t-sql)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1032,8 +1032,8 @@ module.exports = grammar({
             seq(
               ",",
               $._alter_specifications
-            )
-          )
+            ),
+          ),
         ),
       ),
     ),
@@ -1051,14 +1051,26 @@ module.exports = grammar({
       $.change_ownership,
     ),
 
-    add_column: $ => seq(
-      $.keyword_add,
+    _inner_add_column: $ => seq(
       optional(
         $.keyword_column,
       ),
       optional($._if_not_exists),
       $.column_definition,
       optional($.column_position),
+    ),
+
+    add_column: $ => prec.right(
+      seq(
+        $.keyword_add,
+        $._inner_add_column,
+        repeat(
+          seq(
+            ',',
+            $._inner_add_column,
+          )
+        )
+      ),
     ),
 
     add_constraint: $ => seq(

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -599,3 +599,44 @@ FOREIGN KEY ("accountId") REFERENCES "Account" ("accountId") ON DELETE CASCADE;
           (keyword_on)
           (keyword_delete)
           (keyword_cascade))))))
+
+================================================================================
+T-SQL: alter table add multiple columns at once
+================================================================================
+
+ALTER TABLE tab
+ADD
+col1 VARCHAR(255) NOT NULL DEFAULT('EMPTY'),
+col2 VARCHAR(255) NOT NULL DEFAULT('EMPTY');
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (alter_table
+      (keyword_alter)
+      (keyword_table)
+      (table_reference
+        (identifier))
+      (add_column
+        (keyword_add)
+        (column_definition
+          (identifier)
+          (varchar
+            (keyword_varchar)
+            (literal))
+          (keyword_not)
+          (keyword_null)
+          (keyword_default)
+          (list
+            (literal)))
+        (column_definition
+          (identifier)
+          (varchar
+            (keyword_varchar)
+            (literal))
+          (keyword_not)
+          (keyword_null)
+          (keyword_default)
+          (list
+            (literal)))))))


### PR DESCRIPTION
Closes #135

This is an attempt to allow for multiple `alter table` `add` statements, as it is supported by T-SQL.

This does not work at the moment. I need a right precedence on the repeated section for at the `add_column` node, but this breaks the `_alter_specification` one hierarchy level up. I have currently not solution for this problem. @DerekStride, do you have an idea? The issue is that there can be multiple `_alter_specification` that are separated by commas, same as the `_inner_add_column` node that I have added.

Reference:
https://learn.microsoft.com/de-de/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver16