### PR TITLE
feat: add parenthesized select and cte select statements

### DIFF
--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -175,3 +175,41 @@ FROM second;
       (relation
         (table_reference
           (identifier))))))
+
+================================================================================
+Parenthesized CTE
+================================================================================
+
+(
+  WITH data AS (
+    SELECT 1 AS col
+  )
+  SELECT *
+  FROM data
+)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (keyword_with)
+    (cte
+      (identifier)
+      (keyword_as)
+      (statement
+        (select
+          (keyword_select)
+          (select_expression
+            (term
+              (literal)
+              (keyword_as)
+              (identifier))))))
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -2518,3 +2518,19 @@ WHERE (foo OR bar) AND baz
           operator: (keyword_and)
           right: (field
             name: (identifier)))))))
+
+================================================================================
+parenthesized select
+================================================================================
+
+(SELECT 1)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (literal))))))


### PR DESCRIPTION
Addresses a remaining issue in #145 

It works, but I am not so super happy with it. I had to enter alot of associativity rules. Maybe that was necessary, since the change is so high up in the AST and it affects parenthesis.

Also, I am always about creating the anonymous nodes to reduce code replication like in `_cte_select_variants`.

P.S.
For MySQL, this is documented: https://dev.mysql.com/doc/refman/8.0/en/parenthesized-query-expressions.html
