### PR TITLE
refactor: consolidate table_reference and invocation identifier into object_reference

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -9,7 +9,7 @@ module.exports = grammar({
   ],
 
   conflicts: $ => [
-    [$.object_reference, $.field],
+    [$.object_reference, $._qualified_field],
     [$.object_reference],
   ],
 
@@ -630,6 +630,7 @@ module.exports = grammar({
       field(
         'value',
         choice(
+          $._qualified_field,
           seq(
             optional(
               seq(
@@ -637,10 +638,7 @@ module.exports = grammar({
                 '.',
               ),
             ),
-            choice(
-              $.all_fields,
-              $.field,
-            ),
+            $.all_fields,
           ),
           $._expression,
         ),
@@ -1695,6 +1693,16 @@ module.exports = grammar({
 
     field: $ => field('name', $.identifier),
 
+    _qualified_field: $ => seq(
+      optional(
+        seq(
+          $.object_reference,
+          '.',
+        ),
+      ),
+      field('name', $.identifier),
+    ),
+
     implicit_cast: $ => seq(
       $._expression,
       '::',
@@ -2127,13 +2135,8 @@ module.exports = grammar({
     _expression: $ => prec(1,
       choice(
         $.literal,
-        seq(
-          optional(
-            seq(
-              $.object_reference,
-              '.',
-            ),
-          ),
+        alias(
+          $._qualified_field,
           $.field,
         ),
         $.parameter,

--- a/grammar.js
+++ b/grammar.js
@@ -630,16 +630,7 @@ module.exports = grammar({
       field(
         'value',
         choice(
-          $._qualified_field,
-          seq(
-            optional(
-              seq(
-                $.object_reference,
-                '.',
-              ),
-            ),
-            $.all_fields,
-          ),
+          $.all_fields,
           $._expression,
         ),
       ),
@@ -1644,7 +1635,15 @@ module.exports = grammar({
       optional($.direction),
     ),
 
-    all_fields: _ => '*',
+    all_fields: $ => seq(
+      optional(
+        seq(
+          $.object_reference,
+          '.',
+        ),
+      ),
+      '*',
+    ),
 
     parameter: $ => choice(
       "?",

--- a/grammar.js
+++ b/grammar.js
@@ -1921,6 +1921,7 @@ module.exports = grammar({
       ),
       optional($.where),
       optional($.group_by),
+      optional($.window_clause),
       optional($.order_by),
       optional($.limit),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -1265,9 +1265,7 @@ module.exports = grammar({
             '.',
           ),
         ),
-        choice(
-          field('name', $.identifier),
-        ),
+        field('name', $.identifier),
       ),
     ),
 
@@ -1492,7 +1490,7 @@ module.exports = grammar({
     ),
 
     assignment: $ => seq(
-      field('left', $.identifier), // column name only, no schema/table qualifiers
+      field('left', $.field), // column name only, no schema/table qualifiers
       '=',
       field('right', $._expression),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -2110,7 +2110,6 @@ module.exports = grammar({
         choice(
           $.subquery,
           $.invocation,
-          // TODO already has an optional alias
           $.object_reference,
           seq(
             '(',

--- a/grammar.js
+++ b/grammar.js
@@ -1361,8 +1361,7 @@ module.exports = grammar({
           field('alias', $.identifier)
         ),
       ),
-      // TODO i don't think we have a test for `insert into tbl set ....` and
-      // it's no dialect i can think of
+      // TODO we need a test for `insert...set`
       choice(
         $._insert_values,
         $._set_values,

--- a/grammar.js
+++ b/grammar.js
@@ -1503,8 +1503,12 @@ module.exports = grammar({
     ),
 
     assignment: $ => seq(
-      optional($.object_reference), // TODO move into seq in field
-      field('left', $.field),
+      field('left',
+        alias(
+          $._qualified_field,
+          $.field,
+        ),
+      ),
       '=',
       field('right', $._expression),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -11,6 +11,12 @@ module.exports = grammar({
   conflicts: $ => [
     [$.object_reference, $._qualified_field],
     [$.object_reference],
+    // TODO these two have internal conflicts because of optional parenthesized
+    // settings which can be interpreted as _subsequent statements_ due to our
+    // current handling of statement delimiters in program nodes. Remove once
+    // we have expressed programs as delimited sequences of statements.
+    [$._vacuum_table],
+    [$._compute_stats],
   ],
 
   precedences: $ => [

--- a/grammar.js
+++ b/grammar.js
@@ -1303,10 +1303,10 @@ module.exports = grammar({
       ),
       // TODO i don't think we have a test for `insert into tbl set ....` and
       // it's no dialect i can think of
-      // choice(
+      choice(
         $._insert_values,
-        // $._set_values,
-      // ),
+        $._set_values,
+      ),
       optional(
         seq(
           $.keyword_on,

--- a/grammar.js
+++ b/grammar.js
@@ -476,7 +476,13 @@ module.exports = grammar({
     statement: $ => seq(
       choice(
         $._ddl_statement,
-        $._dml_statement,
+        $._dml_read,
+        $._dml_write,
+        seq(
+          '(',
+          $._dml_read,
+          ')',
+        ),
       ),
       optional(';'),
     ),
@@ -498,33 +504,28 @@ module.exports = grammar({
         ),
     ),
 
-    _dml_statement: $ => seq(
+    _dml_write: $ => seq(
+      seq(
+        optional(
+          $._cte,
+        ),
+        choice(
+          $._delete_statement,
+          $._insert_statement,
+          $._update_statement,
+        ),
+      ),
+    ),
+
+    _dml_read: $ => seq(
       choice(
-        $._cte_select_variants,
-        seq('(', $._cte_select_variants,')'),
         seq(
           optional(
             $._cte
           ),
-          choice(
-            $._delete_statement,
-            $._insert_statement,
-            $._update_statement,
-          ),
+          $._select_statement,
         ),
       ),
-      optional($.window_clause),
-    ),
-
-    _cte_select_variants: $ => prec.left(seq(
-      optional(
-        $._cte
-      ),
-      choice(
-        $._select_statement,
-        seq('(', $._select_statement, ')'),
-      )
-    ),
     ),
 
     cte: $ => seq(

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -12,7 +12,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (add_column
         (keyword_add)
@@ -39,7 +39,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (add_column
         (keyword_add)
@@ -65,7 +65,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (add_column
         (keyword_add)
@@ -93,7 +93,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (add_column
         (keyword_add)
@@ -122,7 +122,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (alter_column
         (keyword_alter)
@@ -146,7 +146,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (alter_column
         (keyword_alter)
@@ -169,7 +169,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (alter_column
         (keyword_alter)
@@ -194,7 +194,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (modify_column
         (keyword_modify)
@@ -226,7 +226,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (change_column
         (keyword_change)
@@ -256,7 +256,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (alter_column
         (keyword_alter)
@@ -280,7 +280,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (alter_column
         (keyword_alter)
@@ -304,7 +304,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (drop_column
         (keyword_drop)
@@ -325,7 +325,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (drop_column
         (keyword_drop)
@@ -345,7 +345,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (rename_column
         (keyword_rename)
@@ -368,12 +368,12 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (rename_object
         (keyword_rename)
         (keyword_to)
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -390,7 +390,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (set_schema
         (keyword_set)
@@ -411,7 +411,7 @@ ALTER TABLE my_table
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (change_ownership
         (keyword_owner)
@@ -437,7 +437,7 @@ ALTER TABLE IF EXISTS my_table
       (keyword_table)
       (keyword_if)
       (keyword_exists)
-      (table_reference
+      (object_reference
         name: (identifier))
       (add_column
         (keyword_add)
@@ -483,7 +483,7 @@ ALTER VIEW my_view
     (alter_view
       (keyword_alter)
       (keyword_view)
-      (table_reference
+      (object_reference
         name: (identifier))
       (change_ownership
         (keyword_owner)
@@ -506,12 +506,12 @@ ALTER VIEW IF EXISTS my_view
       (keyword_view)
       (keyword_if)
       (keyword_exists)
-      (table_reference
+      (object_reference
         name: (identifier))
       (rename_object
         (keyword_rename)
         (keyword_to)
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -527,13 +527,12 @@ ALTER TABLE "Role" ADD CONSTRAINT "pkRole" PRIMARY KEY ("roleId");
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (add_constraint
         (keyword_add)
         (keyword_constraint)
-        (field
-          name: (identifier))
+        (identifier)
         (constraint
           (keyword_primary)
           (keyword_key)
@@ -555,13 +554,13 @@ CREATE UNIQUE INDEX "akRoleName" ON "Role" ("name");
       (keyword_create)
       (keyword_unique)
       (keyword_index)
-      (literal)
+      column: (literal)
       (keyword_on)
-      (table_reference
-        (identifier))
+      (object_reference
+        name: (identifier))
       (ordered_columns
         (column
-          (literal))))))
+          name: (literal))))))
 
 ================================================================================
 Add foreign key constraint
@@ -577,13 +576,12 @@ FOREIGN KEY ("accountId") REFERENCES "Account" ("accountId") ON DELETE CASCADE;
     (alter_table
       (keyword_alter)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (add_constraint
         (keyword_add)
         (keyword_constraint)
-        (field
-          name: (identifier))
+        (identifier)
         (constraint
           (keyword_foreign)
           (keyword_key)
@@ -591,7 +589,7 @@ FOREIGN KEY ("accountId") REFERENCES "Account" ("accountId") ON DELETE CASCADE;
             (column
               name: (literal)))
           (keyword_references)
-          (table_reference
+          (object_reference
             name: (identifier))
           (ordered_columns
             (column

--- a/test/corpus/comment.txt
+++ b/test/corpus/comment.txt
@@ -88,7 +88,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -107,7 +107,7 @@ FROM my_table;
     (marginalia)
     (from
       (keyword_from)
-      (table_reference
+      (object_reference
         name: (identifier)))))
 
 ================================================================================
@@ -139,7 +139,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -169,7 +169,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -199,7 +199,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -220,7 +220,7 @@ SELECT '-- foo' FROM bar;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================
@@ -241,7 +241,7 @@ SELECT '/* foo */' FROM bar;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================

--- a/test/corpus/compound_statements.txt
+++ b/test/corpus/compound_statements.txt
@@ -15,7 +15,7 @@ END;
       (create_table
         (keyword_create)
         (keyword_table)
-        (table_reference
+        (object_reference
           (identifier))
         (column_definitions
           (column_definition

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -554,7 +554,7 @@ SELECT * FROM my_table;
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term value: (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -584,7 +584,7 @@ SELECT * FROM my_table;
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term value: (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -743,7 +743,7 @@ WITH NO DATA;
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term value: (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -776,7 +776,7 @@ WITH NO DATA
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term value: (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -1149,7 +1149,7 @@ CREATE TABLE tableName AS SELECT * FROM otherTable;
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term value: (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -1195,7 +1195,7 @@ SELECT * FROM _cte
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -1282,7 +1282,7 @@ SELECT * FROM _cte
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -1329,7 +1329,7 @@ SELECT * FROM _cte
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term (all_fields))))
         (from
           (keyword_from)
           (relation

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -11,7 +11,7 @@ CREATE TABLE my_schema.my_table (id BIGINT NOT NULL PRIMARY KEY);
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         schema: (identifier)
         name: (identifier))
       (column_definitions
@@ -40,7 +40,7 @@ CREATE TABLE my_table (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -74,7 +74,7 @@ CREATE TEMP TABLE my_table (id BIGINT NOT NULL PRIMARY KEY);
       (keyword_create)
       (keyword_temp)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -103,7 +103,7 @@ CREATE TABLE my_table (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -156,7 +156,7 @@ CREATE TABLE my_table (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -177,7 +177,8 @@ CREATE TABLE my_table (
             (keyword_float))
           (keyword_default)
           (invocation
-            name: (identifier)))
+            (object_reference
+              name: (identifier))))
         (column_definition
           name: (identifier)
           type: (keyword_text)
@@ -232,7 +233,7 @@ CREATE TABLE IF NOT EXISTS `addresses` (
       (keyword_if)
       (keyword_not)
       (keyword_exists)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -264,7 +265,7 @@ CREATE TABLE `addresses` (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -327,7 +328,7 @@ CREATE TABLE IF NOT EXISTS `addresses` (
       (keyword_if)
       (keyword_not)
       (keyword_exists)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -377,7 +378,7 @@ CREATE TABLE IF NOT EXISTS `addresses` (
       (keyword_if)
       (keyword_not)
       (keyword_exists)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -458,7 +459,7 @@ CREATE TABLE IF NOT EXISTS `addresses` (
       (keyword_if)
       (keyword_not)
       (keyword_exists)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -502,7 +503,7 @@ CREATE TABLE my_table (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -546,7 +547,7 @@ SELECT * FROM my_table;
     (create_view
       (keyword_create)
       (keyword_view)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_as)
       (create_query
@@ -557,7 +558,7 @@ SELECT * FROM my_table;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier))))))))
 
 ================================================================================
@@ -576,7 +577,7 @@ SELECT * FROM my_table;
       (keyword_or)
       (keyword_replace)
       (keyword_view)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_as)
       (create_query
@@ -587,7 +588,7 @@ SELECT * FROM my_table;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier))))))))
 
 ================================================================================
@@ -605,7 +606,7 @@ CREATE TEMP VIEW foo AS SELECT 1;
       (keyword_create)
       (keyword_temporary)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -619,7 +620,7 @@ CREATE TEMP VIEW foo AS SELECT 1;
       (keyword_create)
       (keyword_temp)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -642,7 +643,7 @@ CREATE VIEW foo(a, b) AS SELECT 1 a, 2 b;
     (create_view
       (keyword_create)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (identifier)
       (identifier)
@@ -672,7 +673,7 @@ CREATE VIEW foo AS SELECT 1 WITH CASCADED CHECK OPTION;
     (create_view
       (keyword_create)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -688,7 +689,7 @@ CREATE VIEW foo AS SELECT 1 WITH CASCADED CHECK OPTION;
     (create_view
       (keyword_create)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -705,7 +706,7 @@ CREATE VIEW foo AS SELECT 1 WITH CASCADED CHECK OPTION;
     (create_view
       (keyword_create)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -735,7 +736,7 @@ WITH NO DATA;
       (keyword_create)
       (keyword_materialized)
       (keyword_view)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_as)
       (create_query
@@ -746,7 +747,7 @@ WITH NO DATA;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier)))))
       (keyword_with)
       (keyword_no)
@@ -768,7 +769,7 @@ WITH NO DATA
       (keyword_create)
       (keyword_materialized)
       (keyword_view)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_as)
       (create_query
@@ -779,7 +780,7 @@ WITH NO DATA
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier)))))
       (keyword_with)
       (keyword_no)
@@ -841,7 +842,7 @@ CREATE TABLE type_test (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -1026,7 +1027,7 @@ CREATE TABLE tableName (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         (identifier))
       (column_definitions
         (column_definition
@@ -1056,7 +1057,7 @@ CREATE UNLOGGED TABLE tableName (
       (keyword_create)
       (keyword_unlogged)
       (keyword_table)
-      (table_reference
+      (object_reference
         (identifier))
       (column_definitions
         (column_definition
@@ -1082,7 +1083,7 @@ CREATE TABLE some_table(
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -1141,7 +1142,7 @@ CREATE TABLE tableName AS SELECT * FROM otherTable;
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_as)
       (create_query
@@ -1152,7 +1153,7 @@ CREATE TABLE tableName AS SELECT * FROM otherTable;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier))))))))
 
 ================================================================================
@@ -1171,7 +1172,7 @@ SELECT * FROM _cte
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -1189,7 +1190,7 @@ SELECT * FROM _cte
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   (identifier))))))
         (select
           (keyword_select)
@@ -1198,7 +1199,7 @@ SELECT * FROM _cte
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               (identifier))))))))
 
 ================================================================================
@@ -1221,7 +1222,7 @@ UNION ALL
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -1258,7 +1259,7 @@ SELECT * FROM _cte
     (create_view
       (keyword_create)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -1276,7 +1277,7 @@ SELECT * FROM _cte
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   (identifier))))))
         (select
           (keyword_select)
@@ -1285,7 +1286,7 @@ SELECT * FROM _cte
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               (identifier))))))))
 
 ================================================================================
@@ -1305,7 +1306,7 @@ SELECT * FROM _cte
       (keyword_create)
       (keyword_materialized)
       (keyword_view)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_as)
       (create_query
@@ -1323,7 +1324,7 @@ SELECT * FROM _cte
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   (identifier))))))
         (select
           (keyword_select)
@@ -1332,7 +1333,7 @@ SELECT * FROM _cte
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               (identifier))))))))
 
 ================================================================================
@@ -1357,7 +1358,7 @@ CACHED IN 'pool1' WITH REPLICATION = 2
       (keyword_create)
       (keyword_external)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -1426,7 +1427,7 @@ CREATE TABLE "Role" (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -1452,7 +1453,7 @@ CREATE TABLE "Role" (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition
@@ -1485,7 +1486,7 @@ CREATE TABLE "Session" (
     (create_table
       (keyword_create)
       (keyword_table)
-      (table_reference
+      (object_reference
         name: (identifier))
       (column_definitions
         (column_definition

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -35,7 +35,7 @@ FROM my_cte;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -83,7 +83,7 @@ FROM second;
         (returning
           (keyword_returning)
           (select_expression
-            (all_fields)))))
+            (term value: (all_fields))))))
     (cte
       (identifier)
       (keyword_as)
@@ -105,7 +105,7 @@ FROM second;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -169,7 +169,7 @@ FROM second;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -207,7 +207,7 @@ Parenthesized CTE
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term (all_fields))))
     (from
       (keyword_from)
       (relation

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -30,7 +30,7 @@ FROM my_cte;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier))))))
     (select
       (keyword_select)
@@ -39,7 +39,7 @@ FROM my_cte;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -69,7 +69,7 @@ FROM second;
         (insert
           (keyword_insert)
           (keyword_into)
-          (table_reference
+          (object_reference
             name: (identifier))
           (list
             (column
@@ -100,7 +100,7 @@ FROM second;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier))))))
     (select
       (keyword_select)
@@ -109,7 +109,7 @@ FROM second;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -145,7 +145,7 @@ FROM second;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               (identifier))))))
     (cte
       (identifier)
@@ -164,7 +164,7 @@ FROM second;
         (from
           (keyword_from)
           (relation
-            (table_reference
+            (object_reference
               (identifier))))))
     (select
       (keyword_select)
@@ -173,7 +173,7 @@ FROM second;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================
@@ -211,5 +211,5 @@ Parenthesized CTE
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -175,3 +175,41 @@ FROM second;
       (relation
         (table_reference
           (identifier))))))
+
+================================================================================
+Parenthesized CTE
+================================================================================
+
+(
+  WITH data AS (
+    SELECT 1 AS col
+  )
+  SELECT *
+  FROM data
+)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (keyword_with)
+    (cte
+      (identifier)
+      (keyword_as)
+      (statement
+        (select
+          (keyword_select)
+          (select_expression
+            (term
+              (literal)
+              (keyword_as)
+              (identifier))))))
+    (select
+      (keyword_select)
+      (select_expression
+        (all_fields)))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier))))))

--- a/test/corpus/delete.txt
+++ b/test/corpus/delete.txt
@@ -12,7 +12,7 @@ DELETE FROM my_table;
       (keyword_delete))
     (from
       (keyword_from)
-      (table_reference
+      (object_reference
         name: (identifier)))))
 
 ================================================================================
@@ -30,7 +30,7 @@ DELETE FROM ONLY my_table;
     (from
       (keyword_from)
       (keyword_only)
-      (table_reference
+      (object_reference
         name: (identifier)))))
 
 ================================================================================
@@ -48,7 +48,7 @@ LIMIT 4;
       (keyword_delete))
     (from
       (keyword_from)
-      (table_reference
+      (object_reference
         name: (identifier))
       (limit
         (keyword_limit)
@@ -70,7 +70,7 @@ LIMIT 4;
       (keyword_delete))
     (from
       (keyword_from)
-      (table_reference
+      (object_reference
         name: (identifier))
       (order_by
         (keyword_order)
@@ -99,7 +99,7 @@ WHERE id = 9;
       (keyword_delete))
     (from
       (keyword_from)
-      (table_reference
+      (object_reference
         name: (identifier))
       (where
         (keyword_where)

--- a/test/corpus/drop.txt
+++ b/test/corpus/drop.txt
@@ -11,7 +11,7 @@ DROP TABLE my_table;
   (drop_table
    (keyword_drop)
    (keyword_table)
-   (table_reference name: (identifier))
+   (object_reference name: (identifier))
   )))
 
 ==================
@@ -27,7 +27,7 @@ DROP TABLE my_table CASCADE;
   (drop_table
    (keyword_drop)
    (keyword_table)
-   (table_reference name: (identifier))
+   (object_reference name: (identifier))
    (keyword_cascade)
   )))
 
@@ -44,7 +44,7 @@ DROP VIEW my_view;
   (drop_view
    (keyword_drop)
    (keyword_view)
-   (table_reference name: (identifier))
+   (object_reference name: (identifier))
   )))
 
 ==================
@@ -77,7 +77,7 @@ DROP INDEX idx ON tbl;
    (keyword_index)
    name: (identifier)
    (keyword_on)
-   (table_reference
+   (object_reference
      name: (identifier)))))
 
 ==================
@@ -99,7 +99,7 @@ DROP INDEX CONCURRENTLY IF EXISTS idx CASCADE ON tbl;
    name: (identifier)
    (keyword_cascade)
    (keyword_on)
-   (table_reference
+   (object_reference
     name: (identifier)))))
 
 ==================
@@ -121,6 +121,6 @@ DROP INDEX CONCURRENTLY IF EXISTS idx RESTRICT ON tbl;
    name: (identifier)
    (keyword_restrict)
    (keyword_on)
-   (table_reference
+   (object_reference
     name: (identifier)))))
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -17,13 +17,14 @@ WHERE m.is_not_deleted;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (field
-          table_alias: (identifier)
+          (object_reference
+            name: (identifier))
           name: (identifier))))))
 
 ================================================================================
@@ -45,18 +46,20 @@ WHERE m.is_not_deleted AND m.is_visible;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           operator: (keyword_and)
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -78,15 +81,16 @@ WHERE NOT m.is_not_deleted;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (unary_expression
           operator: (keyword_not)
           operand: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -109,22 +113,24 @@ WHERE NOT m.is_not_deleted
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (unary_expression
             operator: (keyword_not)
             operand: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier)))
           operator: (keyword_and)
           right: (unary_expression
             operator: (keyword_not)
             operand: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))))))))
 
 ================================================================================
@@ -149,9 +155,9 @@ WHERE m.status = "success"
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (binary_expression
@@ -159,24 +165,28 @@ WHERE m.status = "success"
             left: (binary_expression
               left: (binary_expression
                 left: (field
-                  table_alias: (identifier)
+                  (object_reference
+                    name: (identifier))
                   name: (identifier))
                 right: (literal))
               operator: (keyword_and)
               right: (binary_expression
                 left: (field
-                  table_alias: (identifier)
+                  (object_reference
+                    name: (identifier))
                   name: (identifier))
                 right: (literal)))
             operator: (keyword_and)
             right: (binary_expression
               left: (field
-                table_alias: (identifier)
+                (object_reference
+                  name: (identifier))
                 name: (identifier))
               right: (literal)))
           operator: (keyword_and)
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -201,34 +211,38 @@ WHERE m.status = "success"
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (binary_expression
             left: (binary_expression
               left: (field
-                table_alias: (identifier)
+                (object_reference
+                  name: (identifier))
                 name: (identifier))
               right: (literal))
             operator: (keyword_and)
             right: (binary_expression
               left: (field
-                table_alias: (identifier)
+                (object_reference
+                  name: (identifier))
                 name: (identifier))
               right: (literal)))
           operator: (keyword_or)
           right: (binary_expression
             left: (binary_expression
               left: (field
-                table_alias: (identifier)
+                (object_reference
+                  name: (identifier))
                 name: (identifier))
               right: (literal))
             operator: (keyword_and)
             right: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))))))))
 
 ================================================================================
@@ -250,15 +264,16 @@ WHERE NOT m.is_deleted;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (unary_expression
           operator: (keyword_not)
           operand: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -280,15 +295,16 @@ WHERE !m.is_deleted;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (unary_expression
           operator: (bang)
           operand: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -311,22 +327,24 @@ WHERE NOT m.is_deleted
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (unary_expression
             operator: (keyword_not)
             operand: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier)))
           operator: (keyword_and)
           right: (unary_expression
             operator: (keyword_not)
             operand: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))))))))
 
 ================================================================================
@@ -348,7 +366,7 @@ WHERE col IS DISTINCT FROM NULL;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -381,7 +399,7 @@ WHERE col IS NOT DISTINCT FROM NULL;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -416,7 +434,7 @@ WHERE id IS NOT NULL
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -458,15 +476,16 @@ WHERE m.id > 4 AND id < 3;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (binary_expression
             left: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))
             right: (literal))
           operator: (keyword_and)
@@ -501,7 +520,7 @@ WHERE
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -561,7 +580,7 @@ WHERE
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -13,7 +13,7 @@ WHERE m.is_not_deleted;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -42,7 +42,7 @@ WHERE m.is_not_deleted AND m.is_visible;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -77,7 +77,7 @@ WHERE NOT m.is_not_deleted;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -109,7 +109,7 @@ WHERE NOT m.is_not_deleted
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -151,7 +151,7 @@ WHERE m.status = "success"
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -207,7 +207,7 @@ WHERE m.status = "success"
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -260,7 +260,7 @@ WHERE NOT m.is_deleted;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -291,7 +291,7 @@ WHERE !m.is_deleted;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -323,7 +323,7 @@ WHERE NOT m.is_deleted
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -362,7 +362,7 @@ WHERE col IS DISTINCT FROM NULL;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -395,7 +395,7 @@ WHERE col IS NOT DISTINCT FROM NULL;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -430,7 +430,7 @@ WHERE id IS NOT NULL
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -516,7 +516,7 @@ WHERE
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -576,7 +576,7 @@ WHERE
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -280,7 +280,7 @@ WHERE id = ANY (
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -318,7 +318,7 @@ WHERE id IN (
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -367,7 +367,7 @@ WHERE (
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -927,7 +927,8 @@ $function$
                 (identifier)))
             (keyword_set)
             (assignment
-              (identifier)
+              (field
+                (identifier))
               (binary_expression
                 (field
                   (identifier))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -13,14 +13,15 @@ FROM my_table;
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier)))))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -37,7 +38,8 @@ SELECT now();
       (select_expression
         (term
           value: (invocation
-            name: (identifier)))))))
+            (object_reference
+              name: (identifier))))))))
 
 ================================================================================
 More complex function arguments
@@ -61,7 +63,8 @@ FROM my_table AS t;
             name: (identifier)))
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier)))
@@ -69,7 +72,8 @@ FROM my_table AS t;
               value: (literal))
             parameter: (term
               value: (invocation
-                name: (identifier)
+                (object_reference
+                  name: (identifier))
                 parameter: (term
                   value: (field
                     name: (identifier)))
@@ -86,10 +90,12 @@ FROM my_table AS t;
           alias: (identifier))
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
-                table_alias: (identifier)
+                (object_reference
+                  name: (identifier))
                 name: (identifier)))
             parameter: (term
               value: (literal))
@@ -105,10 +111,10 @@ FROM my_table AS t;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
         (keyword_as)
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Casts and arrays
@@ -130,7 +136,8 @@ select col_has_check(
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (cast
                 (literal)
@@ -167,7 +174,8 @@ FROM table_a;
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier))
@@ -177,7 +185,7 @@ FROM table_a;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -196,22 +204,22 @@ GROUP BY some_field;
       (keyword_select)
       (select_expression
         (term
-          (group_concat
-            (keyword_group_concat)
-            (field
-              (identifier))
+          value: (group_concat
+            name: (keyword_group_concat)
+            parameter: (field
+              name: (identifier))
             (keyword_separator)
             (literal)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
-          (identifier)))
+        (object_reference
+          name: (identifier)))
       (group_by
         (keyword_group)
         (keyword_by)
         (field
-          (identifier))))))
+          name: (identifier))))))
 
 ================================================================================
 GROUP CONCAT with all optional fields
@@ -229,17 +237,17 @@ GROUP BY some_field;
       (keyword_select)
       (select_expression
         (term
-          (group_concat
-            (keyword_group_concat)
+          value: (group_concat
+            name: (keyword_group_concat)
             (keyword_distinct)
-            (field
-              (identifier))
+            parameter: (field
+              name: (identifier))
             (order_by
               (keyword_order)
               (keyword_by)
               (order_target
                 (field
-                  (identifier))
+                  name: (identifier))
                 (direction
                   (keyword_desc))))
             (keyword_separator)
@@ -247,13 +255,13 @@ GROUP BY some_field;
     (from
       (keyword_from)
       (relation
-        (table_reference
-          (identifier)))
+        (object_reference
+          name: (identifier)))
       (group_by
         (keyword_group)
         (keyword_by)
         (field
-          (identifier))))))
+          name: (identifier))))))
 
 ================================================================================
 Unary ANY, ALL, SOME
@@ -276,7 +284,7 @@ WHERE id = ANY (
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -314,7 +322,7 @@ WHERE id IN (
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -331,7 +339,7 @@ WHERE id IN (
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   name: (identifier))))))))))
 
 ================================================================================
@@ -363,7 +371,7 @@ WHERE (
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -381,7 +389,7 @@ WHERE (
                 (from
                   (keyword_from)
                   (relation
-                    (table_reference
+                    (object_reference
                       name: (identifier)))
                   (where
                     (keyword_where)
@@ -398,7 +406,7 @@ WHERE (
               (from
                 (keyword_from)
                 (relation
-                  (table_reference
+                  (object_reference
                     name: (identifier)))
                 (where
                   (keyword_where)
@@ -643,7 +651,7 @@ as 'create table x (id int) row_format=dynamic';
           (create_table
             (keyword_create)
             (keyword_table)
-            (table_reference
+            (object_reference
               (identifier))
             (column_definitions
               (column_definition
@@ -854,22 +862,25 @@ $function$
                 (select_expression
                   (term
                     (field
-                      (identifier)
+                      (object_reference
+                        (identifier))
                       (identifier)))
                   (comment)
                   (term
                     (invocation
-                      (identifier)
+                      (object_reference
+                        (identifier))
                       (term
                         (field
-                          (identifier)
+                          (object_reference
+                            (identifier))
                           (identifier))))
                     (keyword_as)
                     (identifier))))
               (from
                 (keyword_from)
                 (relation
-                  (table_reference
+                  (object_reference
                     (identifier))
                   (identifier))
                 (lateral_cross_join
@@ -895,7 +906,7 @@ $function$
                     (from
                       (keyword_from)
                       (relation
-                        (table_reference
+                        (object_reference
                           (identifier)))
                       (limit
                         (keyword_limit)
@@ -906,17 +917,17 @@ $function$
                   (keyword_group)
                   (keyword_by)
                   (field
-                    (identifier)
+                    (object_reference
+                      (identifier))
                     (identifier))))))
           (update
             (keyword_update)
             (relation
-              (table_reference
+              (object_reference
                 (identifier)))
             (keyword_set)
             (assignment
-              (field
-                (identifier))
+              (identifier)
               (binary_expression
                 (field
                   (identifier))
@@ -925,16 +936,18 @@ $function$
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   (identifier)))
               (where
                 (keyword_where)
                 (binary_expression
                   (field
-                    (identifier)
+                    (object_reference
+                      (identifier))
                     (identifier))
                   (field
-                    (identifier)
+                    (object_reference
+                      (identifier))
                     (identifier)))))))
         (keyword_return)
         (field

--- a/test/corpus/group_by.txt
+++ b/test/corpus/group_by.txt
@@ -19,14 +19,15 @@ HAVING other_id > 10;
             name: (identifier)))
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier)))))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (group_by
         (keyword_group)
@@ -59,14 +60,15 @@ HAVING other_id > 10;
             name: (identifier)))
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier)))))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (group_by
         (keyword_group)
@@ -101,14 +103,15 @@ HAVING other_id > 10;
             name: (identifier)))
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier)))))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (group_by
         (keyword_group)
@@ -143,14 +146,15 @@ HAVING COUNT(*) = 2;
             name: (identifier)))
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier)))))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (group_by
         (keyword_group)
@@ -160,6 +164,7 @@ HAVING COUNT(*) = 2;
         (keyword_having)
         (binary_expression
           left: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (all_fields))
           right: (literal))))))

--- a/test/corpus/group_by.txt
+++ b/test/corpus/group_by.txt
@@ -166,5 +166,5 @@ HAVING COUNT(*) = 2;
           left: (invocation
             (object_reference
               name: (identifier))
-            parameter: (all_fields))
+            parameter: (term value: (all_fields)))
           right: (literal))))))

--- a/test/corpus/index.txt
+++ b/test/corpus/index.txt
@@ -12,7 +12,7 @@ CREATE INDEX ON tab(col);
       (keyword_create)
       (keyword_index)
       (keyword_on)
-      (table_reference
+      (object_reference
         (identifier))
       (ordered_columns
         (column
@@ -41,7 +41,7 @@ WHERE tab.col > 10;
       (keyword_exists)
       (identifier)
       (keyword_on)
-      (table_reference
+      (object_reference
         (identifier))
       (keyword_using)
       (keyword_hash)
@@ -54,6 +54,7 @@ WHERE tab.col > 10;
         (keyword_where)
         (binary_expression
           (field
-            (identifier)
+            (object_reference
+              (identifier))
             (identifier))
           (literal))))))

--- a/test/corpus/insert.txt
+++ b/test/corpus/insert.txt
@@ -311,7 +311,8 @@ ON CONFLICT DO UPDATE SET dname = EXCLUDED.dname;
       (keyword_update)
       (keyword_set)
       (assignment
-        left: (identifier)
+        left: (field
+          name: (identifier))
         right: (field
           (object_reference
             name: (identifier))

--- a/test/corpus/insert.txt
+++ b/test/corpus/insert.txt
@@ -12,7 +12,7 @@ VALUES('foo','bar', 3);
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -34,10 +34,10 @@ VALUES('foo','bar', 3);
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_as)
-      table_alias: (identifier)
+      alias: (identifier)
       (keyword_values)
       (list
         (literal)
@@ -58,7 +58,7 @@ VALUES ('foo', 123, '2020');
     (insert
       (keyword_replace)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (list
         (column
@@ -88,7 +88,7 @@ FROM my_other_table;
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (list
         (column
@@ -112,7 +112,7 @@ FROM my_other_table;
       (from
         (keyword_from)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier)))))))
 
 ================================================================================
@@ -130,7 +130,7 @@ RETURNING *;
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -157,7 +157,7 @@ RETURNING id;
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -186,7 +186,7 @@ RETURNING id, val1, val2;
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -223,7 +223,7 @@ VALUES
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         (identifier))
       (list
         (column
@@ -248,7 +248,7 @@ INSERT INTO some_table
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_set)
       (assignment
@@ -271,7 +271,7 @@ ON CONFLICT DO NOTHING;
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -298,7 +298,7 @@ ON CONFLICT DO UPDATE SET dname = EXCLUDED.dname;
     (insert
       (keyword_insert)
       (keyword_into)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -311,10 +311,10 @@ ON CONFLICT DO UPDATE SET dname = EXCLUDED.dname;
       (keyword_update)
       (keyword_set)
       (assignment
-        left: (field
-          name: (identifier))
+        left: (identifier)
         right: (field
-          table_alias: (identifier)
+          (object_reference
+            name: (identifier))
           name: (identifier))))))
 
 ================================================================================
@@ -331,7 +331,7 @@ VALUES('foo','bar', 3);
     (insert
       (keyword_insert)
       (keyword_low_priority)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -353,7 +353,7 @@ VALUES('foo','bar', 3);
     (insert
       (keyword_insert)
       (keyword_delayed)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -375,7 +375,7 @@ VALUES('foo','bar', 3);
     (insert
       (keyword_insert)
       (keyword_high_priority)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -397,7 +397,7 @@ VALUES('foo','bar', 3);
     (insert
       (keyword_insert)
       (keyword_ignore)
-      (table_reference
+      (object_reference
         name: (identifier))
       (keyword_values)
       (list
@@ -430,7 +430,7 @@ FROM
     (insert
       (keyword_insert)
       (keyword_overwrite)
-      (table_reference
+      (object_reference
         (identifier))
       (select
         (keyword_select)
@@ -452,7 +452,7 @@ FROM
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   (identifier)))
               (where
                 (keyword_where)
@@ -488,7 +488,7 @@ FROM
     (insert
       (keyword_insert)
       (keyword_overwrite)
-      (table_reference
+      (object_reference
         (identifier))
       (table_partition
         (keyword_partition)
@@ -516,7 +516,7 @@ FROM
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   (identifier)))
               (where
                 (keyword_where)

--- a/test/corpus/insert.txt
+++ b/test/corpus/insert.txt
@@ -140,7 +140,7 @@ RETURNING *;
     (returning
       (keyword_returning)
       (select_expression
-        (all_fields)))))
+        (term value: (all_fields))))))
 
 ================================================================================
 Insert returning single column
@@ -449,7 +449,7 @@ FROM
             (select
               (keyword_select)
               (select_expression
-                (all_fields)))
+                (term (all_fields))))
             (from
               (keyword_from)
               (relation
@@ -513,7 +513,7 @@ FROM
             (select
               (keyword_select)
               (select_expression
-                (all_fields)))
+                (term (all_fields))))
             (from
               (keyword_from)
               (relation

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -57,7 +57,7 @@ SELECT * FROM my_table;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -77,7 +77,7 @@ SELECT * FROM ONLY my_table;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (keyword_only)
@@ -98,9 +98,10 @@ SELECT my_table.* FROM my_table;
     (select
       (keyword_select)
       (select_expression
-        (all_fields
-          (object_reference
-            name: (identifier)))))
+        (term
+          value: (all_fields
+            (object_reference
+              name: (identifier))))))
     (from
       (keyword_from)
       (relation
@@ -120,9 +121,10 @@ SELECT t.* FROM my_table AS t;
     (select
       (keyword_select)
       (select_expression
-        (all_fields
-          (object_reference
-            name: (identifier)))))
+        (term
+          value: (all_fields
+            (object_reference
+              name: (identifier))))))
     (from
       (keyword_from)
       (relation
@@ -646,7 +648,7 @@ SELECT * FROM my_schema.my_table;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -882,7 +884,7 @@ JOIN my_other_table ON TRUE;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -1058,7 +1060,7 @@ JOIN (VALUES (1, 2), (3, 4)) AS v (col1, col2) ON TRUE;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -1268,9 +1270,10 @@ JOIN LATERAL unnest(a.arr) AS arr ON TRUE;
             (object_reference
               name: (identifier))
             name: (identifier)))
-        (all_fields
-          (object_reference
-            name: (identifier)))))
+        (term
+          value: (all_fields
+            (object_reference
+              name: (identifier))))))
     (from
       (keyword_from)
       (relation
@@ -1314,9 +1317,10 @@ CROSS JOIN LATERAL (SELECT 1) AS b;
             (object_reference
               name: (identifier))
             name: (identifier)))
-        (all_fields
-          (object_reference
-            name: (identifier)))))
+        (term
+          value: (all_fields
+            (object_reference
+              name: (identifier))))))
     (from
       (keyword_from)
       (relation
@@ -2049,7 +2053,7 @@ FROM
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -2084,7 +2088,7 @@ WHERE id = ?;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -2112,7 +2116,7 @@ WHERE id = $12;
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -2150,7 +2154,7 @@ FROM
           (select
             (keyword_select)
             (select_expression
-              (all_fields)))
+              (term value: (all_fields))))
           (from
             (keyword_from)
             (relation
@@ -2175,7 +2179,7 @@ FROM
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation
@@ -2188,7 +2192,7 @@ FROM
             (literal)
             (literal)))
         (keyword_as)
-        (identifier)
+        alias: (identifier)
         (list
           (column
             (identifier))
@@ -2223,7 +2227,7 @@ FROM test_data;
         (select
           (keyword_select)
           (select_expression
-            (all_fields)))
+            (term value: (all_fields))))
         (from
           (keyword_from)
           (relation
@@ -2233,7 +2237,7 @@ FROM test_data;
                 (literal
                   (keyword_true))))
             (keyword_as)
-            (identifier)
+            alias: (identifier)
             (list
               (column
                 (identifier)))))))
@@ -2241,21 +2245,21 @@ FROM test_data;
       (keyword_select)
       (select_expression
         (term
-          (case
+          value: (case
             (keyword_case)
             (keyword_when)
             (field
-              (identifier))
+              name: (identifier))
             (keyword_then)
             (literal)
             (keyword_end))
           (keyword_as)
-          (identifier))))
+          alias: (identifier))))
     (from
       (keyword_from)
       (relation
         (object_reference
-          (identifier))))))
+          name: (identifier))))))
 
 ================================================================================
 No semi-colon
@@ -2271,7 +2275,7 @@ FROM some_table s
     (select
       (keyword_select)
       (select_expression
-        (all_fields)))
+        (term value: (all_fields))))
     (from
       (keyword_from)
       (relation

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -675,6 +675,7 @@ FROM
         (term
           value: (field
             (object_reference
+              schema: (identifier)
               name: (identifier))
             name: (identifier)))))
     (from
@@ -777,7 +778,7 @@ FROM my_table;
           value: (invocation
             (object_reference
               name: (identifier))
-            parameter: (all_fields)))))
+            parameter: (term value: (all_fields))))))
     (from
       (keyword_from)
       (relation

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -2518,3 +2518,19 @@ WHERE (foo OR bar) AND baz
           operator: (keyword_and)
           right: (field
             name: (identifier)))))))
+
+================================================================================
+parenthesized select
+================================================================================
+
+(SELECT 1)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (literal))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -61,7 +61,7 @@ SELECT * FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -82,7 +82,7 @@ SELECT * FROM ONLY my_table;
       (keyword_from)
       (keyword_only)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -99,11 +99,12 @@ SELECT my_table.* FROM my_table;
       (keyword_select)
       (select_expression
         (all_fields
-          table_alias: (identifier))))
+          (object_reference
+            name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -120,14 +121,15 @@ SELECT t.* FROM my_table AS t;
       (keyword_select)
       (select_expression
         (all_fields
-          table_alias: (identifier))))
+          (object_reference
+            name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
         (keyword_as)
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Simple select with fields
@@ -151,7 +153,7 @@ SELECT id, name FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -170,23 +172,26 @@ FROM join_something_on AS where_this_like_that;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
         (keyword_as)
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Simple select with fields field table alias
@@ -204,18 +209,20 @@ FROM my_table m;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Simple select with aliased table and column name using double quotes
@@ -233,16 +240,17 @@ FROM my_table "My Table";
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           (keyword_as)
           alias: (identifier))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Select with quoted column
@@ -259,12 +267,13 @@ SELECT tab."COL" FROM tab;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -288,7 +297,7 @@ WHERE id = 4;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -318,7 +327,7 @@ WHERE id = "abc";
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -348,7 +357,7 @@ WHERE id IN(1,2);
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -376,10 +385,12 @@ FROM my_table m;
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
-                table_alias: (identifier)
+                (object_reference
+                  name: (identifier))
                 name: (identifier)))
             parameter: (term
               value: (literal))
@@ -390,9 +401,9 @@ FROM my_table m;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Select with complex IF
@@ -410,15 +421,18 @@ FROM my_table m;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (binary_expression
                 left: (field
-                  table_alias: (identifier)
+                  (object_reference
+                    name: (identifier))
                   name: (identifier))
                 right: (literal)))
             parameter: (term
@@ -429,9 +443,9 @@ FROM my_table m;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Select with distinct without parenthesis
@@ -454,7 +468,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -473,7 +487,8 @@ FROM my_table;
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier))
@@ -483,7 +498,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -502,22 +517,24 @@ FROM my_table AS m;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           (keyword_as)
           alias: (identifier))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           alias: (identifier))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
         (keyword_as)
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Simple select with order by
@@ -541,7 +558,7 @@ ORDER BY id DESC;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -579,7 +596,7 @@ LIMIT 5;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (limit
         (keyword_limit)
@@ -607,7 +624,7 @@ OFFSET 40;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (limit
         (keyword_limit)
@@ -633,7 +650,7 @@ SELECT * FROM my_schema.my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           schema: (identifier)
           name: (identifier))))))
 
@@ -655,13 +672,13 @@ FROM
       (select_expression
         (term
           value: (field
-            schema: (identifier)
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           schema: (identifier)
           name: (identifier))))))
 
@@ -685,7 +702,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -708,7 +725,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -726,17 +743,19 @@ FROM my_table;
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (invocation
-                name: (identifier)
+                (object_reference
+                  name: (identifier))
                 parameter: (term
                   value: (field
                     name: (identifier)))))))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -754,12 +773,13 @@ FROM my_table;
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (all_fields)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -777,7 +797,8 @@ FROM my_table;
       (select_expression
         (term
           value: (invocation
-            name: (identifier)
+            (object_reference
+              name: (identifier))
             parameter: (term
               value: (field
                 name: (identifier))
@@ -785,7 +806,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -807,37 +828,42 @@ WHERE b.c_id = 4;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (literal))))))
 
@@ -860,12 +886,12 @@ JOIN my_other_table ON TRUE;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier)))
         (keyword_on)
         predicate: (literal
@@ -889,24 +915,26 @@ ON a.id = b.a_id;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (index_hint
           (keyword_use)
           (keyword_index)
@@ -916,10 +944,12 @@ ON a.id = b.a_id;
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -943,15 +973,15 @@ ON a.id = b.a_id;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (index_hint
           (keyword_ignore)
           (keyword_index)
@@ -961,10 +991,12 @@ ON a.id = b.a_id;
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -984,24 +1016,26 @@ JOIN my_other_table b USING (q, w);
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_using)
         (list
           (column
@@ -1028,7 +1062,7 @@ JOIN (VALUES (1, 2), (3, 4)) AS v (col1, col2) ON TRUE;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (join
         (keyword_join)
@@ -1042,7 +1076,7 @@ JOIN (VALUES (1, 2), (3, 4)) AS v (col1, col2) ON TRUE;
               (literal)
               (literal)))
           (keyword_as)
-          table_alias: (identifier)
+          alias: (identifier)
           (list
             (column
               (identifier))
@@ -1082,121 +1116,136 @@ ON a.id = g.g_id;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (join
         (keyword_left)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_left)
         (keyword_outer)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_right)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_right)
         (keyword_outer)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_inner)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_full)
         (keyword_outer)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_full)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -1216,24 +1265,28 @@ JOIN LATERAL unnest(a.arr) AS arr ON TRUE;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (all_fields
-          table_alias: (identifier))))
+          (object_reference
+            name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (lateral_join
         (keyword_join)
         (keyword_lateral)
         (invocation
-          name: (identifier)
+          (object_reference
+            name: (identifier))
           parameter: (term
             value: (field
-              table_alias: (identifier)
+            (object_reference
+              name: (identifier))
               name: (identifier))))
         (keyword_as)
         alias: (identifier)
@@ -1258,16 +1311,18 @@ CROSS JOIN LATERAL (SELECT 1) AS b;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (all_fields
-          table_alias: (identifier))))
+          (object_reference
+            name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (lateral_cross_join
         (keyword_cross)
         (keyword_join)
@@ -1305,78 +1360,89 @@ ON c.id = d.c_id;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (join
         (keyword_left)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (join
           (keyword_join)
           (relation
-            (table_reference
+            (object_reference
               name: (identifier))
-            table_alias: (identifier))
+            alias: (identifier))
           (keyword_on)
           predicate: (binary_expression
             left: (field
-              table_alias: (identifier)
+            (object_reference
+              name: (identifier))
               name: (identifier))
             right: (field
-              table_alias: (identifier)
+            (object_reference
+              name: (identifier))
               name: (identifier))))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -1404,15 +1470,16 @@ ORDER BY m.title, id ASC;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (binary_expression
             left: (field
-              table_alias: (identifier)
+            (object_reference
+              name: (identifier))
               name: (identifier))
             right: (literal))
           operator: (keyword_and)
@@ -1425,7 +1492,8 @@ ORDER BY m.title, id ASC;
         (keyword_by)
         (order_target
           (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (order_target
           (field
@@ -1455,7 +1523,7 @@ ORDER BY id DESC NULLS LAST, val USING < NULLS FIRST;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -1501,7 +1569,7 @@ LIMIT 1;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (index_hint
         (keyword_force)
@@ -1532,7 +1600,7 @@ LIMIT 1;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (index_hint
         (keyword_use)
@@ -1586,7 +1654,7 @@ SELECT b FROM two;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))
     (keyword_intersect)
     (select
@@ -1598,7 +1666,7 @@ SELECT b FROM two;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================
@@ -1635,7 +1703,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================
@@ -1711,7 +1779,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================
@@ -1779,7 +1847,7 @@ FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================
@@ -1806,7 +1874,7 @@ SELECT id || '-' || name FROM my_table;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -1837,18 +1905,20 @@ ORDER BY my_table.title, my_table.id;
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (index_hint
         (keyword_force)
         (keyword_index)
@@ -1856,30 +1926,34 @@ ORDER BY my_table.title, my_table.id;
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (binary_expression
             left: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))
             right: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier)))
           operator: (keyword_and)
           right: (binary_expression
             left: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))
             right: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier)))))
       (join
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier)))
         (index_hint
           (keyword_use)
@@ -1891,18 +1965,22 @@ ORDER BY my_table.title, my_table.id;
         predicate: (binary_expression
           left: (binary_expression
             left: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))
             right: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier)))
           operator: (keyword_and)
           right: (binary_expression
             left: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))
             right: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier)))))
       (where
         (keyword_where)
@@ -1911,13 +1989,15 @@ ORDER BY my_table.title, my_table.id;
             left: (binary_expression
               left: (binary_expression
                 left: (field
-                  table_alias: (identifier)
+                  (object_reference
+                    name: (identifier))
                   name: (identifier))
                 right: (literal))
               operator: (keyword_and)
               right: (binary_expression
                 left: (field
-                  table_alias: (identifier)
+                  (object_reference
+                    name: (identifier))
                   name: (identifier))
                 operator: (keyword_in)
                 right: (list
@@ -1925,13 +2005,15 @@ ORDER BY my_table.title, my_table.id;
             operator: (keyword_and)
             right: (binary_expression
               left: (field
-                table_alias: (identifier)
+                (object_reference
+                  name: (identifier))
                 name: (identifier))
               right: (literal)))
           operator: (keyword_and)
           right: (binary_expression
             left: (field
-              table_alias: (identifier)
+              (object_reference
+                name: (identifier))
               name: (identifier))
             right: (literal
               (keyword_true)))))
@@ -1940,11 +2022,13 @@ ORDER BY my_table.title, my_table.id;
         (keyword_by)
         (order_target
           (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (order_target
           (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -1969,21 +2053,21 @@ FROM
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Parameterized Queries
@@ -2004,7 +2088,7 @@ WHERE id = ?;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -2032,7 +2116,7 @@ WHERE id = $12;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -2070,10 +2154,10 @@ FROM
           (from
             (keyword_from)
             (relation
-              (table_reference
+              (object_reference
                 name: (identifier)))))
         (keyword_as)
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Select from inplace values insert
@@ -2170,7 +2254,7 @@ FROM test_data;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier))))))
 
 ================================================================================
@@ -2191,9 +2275,9 @@ FROM some_table s
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier)))))
+        alias: (identifier)))))
 
 ================================================================================
 Aliases everywhere
@@ -2219,45 +2303,51 @@ WHERE
       (select_expression
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           (keyword_as)
           alias: (identifier))
         (comment)
         (term
           value: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))
-        table_alias: (identifier))
+        alias: (identifier))
       (join
         (keyword_left)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             name: (identifier))
-          table_alias: (identifier))
+          alias: (identifier))
         (keyword_on)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (literal))))))
 
@@ -2275,19 +2365,20 @@ SELECT array[1, 2, 3 + 4, '5'::int, int_please()];
       (keyword_select)
       (select_expression
         (term
-          (array
+          value: (array
             (keyword_array)
             (literal)
             (literal)
             (binary_expression
-              (literal)
-              (literal))
+              left: (literal)
+              right: (literal))
             (cast
               (literal)
               (int
                 (keyword_int)))
             (invocation
-              (identifier))))))))
+              (object_reference
+                name: (identifier)))))))))
 
 ================================================================================
 Select with positive and negative integers
@@ -2310,7 +2401,7 @@ SELECT a + 3 from b where a >= -14
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -2340,7 +2431,7 @@ SELECT a + 3.1415 from b where a >= -3.14
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)
@@ -2437,7 +2528,7 @@ where a between '2022-01-01' and '2023-01-01'
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier)))
       (where
         (keyword_where)
@@ -2471,7 +2562,7 @@ where a not between 1 and 3
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier)))
       (where
         (keyword_where)
@@ -2504,7 +2595,7 @@ WHERE (foo OR bar) AND baz
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (where
         (keyword_where)

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -657,6 +657,34 @@ SELECT * FROM my_schema.my_table;
           name: (identifier))))))
 
 ================================================================================
+Simple select with schema and fully-qualified *
+================================================================================
+
+SELECT
+  my_schema.my_table.*
+FROM
+  my_schema.my_table;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (all_fields
+            (object_reference
+              schema: (identifier)
+              name: (identifier))))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          schema: (identifier)
+          name: (identifier))))))
+
+================================================================================
 Simple select with schema and fully-pathed fields
 ================================================================================
 

--- a/test/corpus/subquery.txt
+++ b/test/corpus/subquery.txt
@@ -22,7 +22,7 @@ WHERE id < (
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           (identifier)))
       (where
         (keyword_where)
@@ -39,7 +39,7 @@ WHERE id < (
             (from
               (keyword_from)
               (relation
-                (table_reference
+                (object_reference
                   (identifier)))
               (limit
                 (keyword_limit)

--- a/test/corpus/transaction.txt
+++ b/test/corpus/transaction.txt
@@ -1,20 +1,20 @@
-==================
+================================================================================
 Empty transaction
-==================
+================================================================================
 
 BEGIN;
 COMMIT;
 
----
+--------------------------------------------------------------------------------
 
 (program
- (transaction
-  (keyword_begin)
-  (keyword_commit)))
+  (transaction
+    (keyword_begin)
+    (keyword_commit)))
 
-==================
+================================================================================
 Transaction begin and commit
-==================
+================================================================================
 
 BEGIN;
 ALTER TABLE my_table
@@ -22,92 +22,102 @@ ALTER TABLE my_table
 UPDATE my_table SET val3 = 'new';
 COMMIT;
 
----
+--------------------------------------------------------------------------------
 
 (program
- (transaction
-  (keyword_begin)
-  (statement
-   (alter_table
-    (keyword_alter)
-    (keyword_table)
-    (object_reference name: (identifier))
-    (add_column (keyword_add) (keyword_column)
-     (column_definition
-      name: (identifier)
-      type: (varchar
-        (keyword_varchar)
-        size: (literal))
-      (keyword_not)
-      (keyword_null)))))
-  (statement
-   (update
-    (keyword_update)
-    (relation
-     (object_reference
-      name: (identifier)))
-    (keyword_set)
-    (assignment
-      left: (identifier)
-      right: (literal))))
- (keyword_commit)))
+  (transaction
+    (keyword_begin)
+    (statement
+      (alter_table
+        (keyword_alter)
+        (keyword_table)
+        (object_reference
+          name: (identifier))
+        (add_column
+          (keyword_add)
+          (keyword_column)
+          (column_definition
+            name: (identifier)
+            type: (varchar
+              (keyword_varchar)
+              size: (literal))
+            (keyword_not)
+            (keyword_null)))))
+    (statement
+      (update
+        (keyword_update)
+        (relation
+          (object_reference
+            name: (identifier)))
+        (keyword_set)
+        (assignment
+          left: (field
+            name: (identifier))
+          right: (literal))))
+    (keyword_commit)))
 
-==================
+================================================================================
 Transaction begin and rollback
-==================
+================================================================================
 
 BEGIN;
 ALTER TABLE my_table
   ADD COLUMN val3 VARCHAR(100) NOT NULL;
 ROLLBACK;
 
----
+--------------------------------------------------------------------------------
 
 (program
- (transaction
-  (keyword_begin)
-  (statement
-   (alter_table
-    (keyword_alter)
-    (keyword_table)
-    (object_reference name: (identifier))
-    (add_column (keyword_add) (keyword_column)
-     (column_definition
-      name: (identifier)
-      type: (varchar
-        (keyword_varchar)
-        size: (literal))
-      (keyword_not)
-      (keyword_null)))))
-  (keyword_rollback)))
+  (transaction
+    (keyword_begin)
+    (statement
+      (alter_table
+        (keyword_alter)
+        (keyword_table)
+        (object_reference
+          name: (identifier))
+        (add_column
+          (keyword_add)
+          (keyword_column)
+          (column_definition
+            name: (identifier)
+            type: (varchar
+              (keyword_varchar)
+              size: (literal))
+            (keyword_not)
+            (keyword_null)))))
+    (keyword_rollback)))
 
-==================
+================================================================================
 Use explicit transaction keywords
-==================
+================================================================================
 
 BEGIN TRANSACTION;
 ALTER TABLE my_table
   ADD COLUMN val3 VARCHAR(100) NOT NULL;
 ROLLBACK TRANSACTION;
 
----
+--------------------------------------------------------------------------------
 
 (program
- (transaction
-  (keyword_begin)
-  (keyword_transaction)
-  (statement
-   (alter_table
-    (keyword_alter)
-    (keyword_table)
-    (object_reference name: (identifier))
-    (add_column (keyword_add) (keyword_column)
-     (column_definition
-      name: (identifier)
-      type: (varchar
-        (keyword_varchar)
-        size: (literal))
-      (keyword_not)
-      (keyword_null)))))
-  (keyword_rollback)
-  (keyword_transaction)))
+  (transaction
+    (keyword_begin)
+    (keyword_transaction)
+    (statement
+      (alter_table
+        (keyword_alter)
+        (keyword_table)
+        (object_reference
+          name: (identifier))
+        (add_column
+          (keyword_add)
+          (keyword_column)
+          (column_definition
+            name: (identifier)
+            type: (varchar
+              (keyword_varchar)
+              size: (literal))
+            (keyword_not)
+            (keyword_null)))))
+    (keyword_rollback)
+    (keyword_transaction)))

--- a/test/corpus/transaction.txt
+++ b/test/corpus/transaction.txt
@@ -31,7 +31,7 @@ COMMIT;
    (alter_table
     (keyword_alter)
     (keyword_table)
-    (table_reference name: (identifier))
+    (object_reference name: (identifier))
     (add_column (keyword_add) (keyword_column)
      (column_definition
       name: (identifier)
@@ -44,12 +44,11 @@ COMMIT;
    (update
     (keyword_update)
     (relation
-     (table_reference
+     (object_reference
       name: (identifier)))
     (keyword_set)
     (assignment
-      left: (field
-        name: (identifier))
+      left: (identifier)
       right: (literal))))
  (keyword_commit)))
 
@@ -71,7 +70,7 @@ ROLLBACK;
    (alter_table
     (keyword_alter)
     (keyword_table)
-    (table_reference name: (identifier))
+    (object_reference name: (identifier))
     (add_column (keyword_add) (keyword_column)
      (column_definition
       name: (identifier)
@@ -101,7 +100,7 @@ ROLLBACK TRANSACTION;
    (alter_table
     (keyword_alter)
     (keyword_table)
-    (table_reference name: (identifier))
+    (object_reference name: (identifier))
     (add_column (keyword_add) (keyword_column)
      (column_definition
       name: (identifier)

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -16,7 +16,8 @@ SET for = foo + 1;
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (identifier)
+        left: (field
+          name: (identifier))
         right: (binary_expression
           left: (field
             name: (identifier))
@@ -41,7 +42,8 @@ SET for = foo + 1;
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (identifier)
+        left: (field
+          name: (identifier))
         right: (binary_expression
           left: (field
             name: (identifier))
@@ -65,13 +67,15 @@ SET for = foo + 1, col2 = col1;
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (identifier)
+        left: (field
+          name: (identifier))
         right: (binary_expression
           left: (field
             name: (identifier))
           right: (literal)))
       (assignment
-        left: (identifier)
+        left: (field
+          name: (identifier))
         right: (field
           name: (identifier))))))
 
@@ -135,7 +139,8 @@ SET ts = now();
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (identifier)
+        left: (field
+          name: (identifier))
         right: (invocation
           (object_reference
             name: (identifier)))))))
@@ -196,7 +201,10 @@ a.d = 5;
             (identifier))))
       (keyword_set)
       (assignment
-        (identifier)
+        (field
+          (object_reference
+            (identifier))
+          (identifier))
         (literal)))))
 
 ================================================================================
@@ -220,7 +228,8 @@ WHERE b.a = a.uid;
         (identifier))
       (keyword_set)
       (assignment
-        (identifier)
+        (field
+          (identifier))
         (literal))
       (where
         (keyword_where)
@@ -257,7 +266,8 @@ WHERE b.a = a.uid;
         (identifier))
       (keyword_set)
       (assignment
-        (identifier)
+        (field
+          (identifier))
         (literal))
       (from
         (keyword_from)

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -12,12 +12,11 @@ SET for = foo + 1;
     (update
       (keyword_update)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (field
-          name: (identifier))
+        left: (identifier)
         right: (binary_expression
           left: (field
             name: (identifier))
@@ -38,12 +37,11 @@ SET for = foo + 1;
       (keyword_update)
       (keyword_only)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (field
-          name: (identifier))
+        left: (identifier)
         right: (binary_expression
           left: (field
             name: (identifier))
@@ -63,19 +61,17 @@ SET for = foo + 1, col2 = col1;
     (update
       (keyword_update)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (field
-          name: (identifier))
+        left: (identifier)
         right: (binary_expression
           left: (field
             name: (identifier))
           right: (literal)))
       (assignment
-        left: (field
-          name: (identifier))
+        left: (identifier)
         right: (field
           name: (identifier))))))
 
@@ -94,27 +90,31 @@ WHERE items.id=month.item_id;
     (update
       (keyword_update)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (keyword_set)
       (assignment
         left: (field
-          table_alias: (identifier)
+          (object_reference
+            name: (identifier))
           name: (identifier))
         right: (field
-          table_alias: (identifier)
+          (object_reference
+            name: (identifier))
           name: (identifier)))
       (where
         (keyword_where)
         predicate: (binary_expression
           left: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier))
           right: (field
-            table_alias: (identifier)
+            (object_reference
+              name: (identifier))
             name: (identifier)))))))
 
 ================================================================================
@@ -131,14 +131,14 @@ SET ts = now();
     (update
       (keyword_update)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier)))
       (keyword_set)
       (assignment
-        left: (field
-          name: (identifier))
+        left: (identifier)
         right: (invocation
-          name: (identifier))))))
+          (object_reference
+            name: (identifier)))))))
 
 ================================================================================
 Update with a JOIN
@@ -157,14 +157,14 @@ a.d = 5;
     (update
       (keyword_update)
       (relation
-        (table_reference
+        (object_reference
           (identifier))
         (identifier))
       (join
         (keyword_inner)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             (identifier))
           (identifier))
         (keyword_on)
@@ -179,7 +179,7 @@ a.d = 5;
         (keyword_inner)
         (keyword_join)
         (relation
-          (table_reference
+          (object_reference
             (identifier))
           (identifier))
         (keyword_on)
@@ -212,23 +212,24 @@ WHERE b.a = a.uid;
     (update
       (keyword_update)
       (relation
-        (table_reference
+        (object_reference
           (identifier))
         (keyword_as)
         (identifier))
       (keyword_set)
       (assignment
-        (field
-          (identifier))
+        (identifier)
         (literal))
       (where
         (keyword_where)
         (binary_expression
           (field
-            (identifier)
+            (object_reference
+              (identifier))
             (identifier))
           (field
-            (identifier)
+            (object_reference
+              (identifier))
             (identifier)))))))
 
 ================================================================================
@@ -248,42 +249,45 @@ WHERE b.a = a.uid;
     (update
       (keyword_update)
       (relation
-        (table_reference
+        (object_reference
           (identifier))
         (keyword_as)
         (identifier))
       (keyword_set)
       (assignment
-        (field
-          (identifier))
+        (identifier)
         (literal))
       (from
         (keyword_from)
         (relation
-          (table_reference
+          (object_reference
             (identifier))
           (identifier))
         (join
           (keyword_inner)
           (keyword_join)
           (relation
-            (table_reference
+            (object_reference
               (identifier))
             (identifier))
           (keyword_on)
           (binary_expression
             (field
-              (identifier)
+              (object_reference
+                (identifier))
               (identifier))
             (field
-              (identifier)
+              (object_reference
+                (identifier))
               (identifier))))
         (where
           (keyword_where)
           (binary_expression
             (field
-              (identifier)
+              (object_reference
+                (identifier))
               (identifier))
             (field
-              (identifier)
+              (object_reference
+                (identifier))
               (identifier))))))))

--- a/test/corpus/update.txt
+++ b/test/corpus/update.txt
@@ -170,10 +170,12 @@ a.d = 5;
         (keyword_on)
         (binary_expression
           (field
-            (identifier)
+            (object_reference
+              (identifier))
             (identifier))
           (field
-            (identifier)
+            (object_reference
+              (identifier))
             (identifier))))
       (join
         (keyword_inner)
@@ -185,16 +187,16 @@ a.d = 5;
         (keyword_on)
         (binary_expression
           (field
-            (identifier)
+            (object_reference
+              (identifier))
             (identifier))
           (field
-            (identifier)
+            (object_reference
+              (identifier))
             (identifier))))
       (keyword_set)
       (assignment
-        (field
-          (identifier)
-          (identifier))
+        (identifier)
         (literal)))))
 
 ================================================================================

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -739,7 +739,7 @@ FROM tab1
             (invocation
               (object_reference
                 name: (identifier))
-              parameter: (all_fields))
+              parameter: (term value: (all_fields)))
             (keyword_over)
             (window_specification
               (partition_by

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -28,7 +28,8 @@ FROM tab1;
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -42,7 +43,7 @@ FROM tab1;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -75,7 +76,8 @@ FROM tab1;
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -94,7 +96,7 @@ FROM tab1;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -127,7 +129,8 @@ FROM tab1;
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -151,7 +154,7 @@ FROM tab1;
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -171,24 +174,25 @@ FROM tab1;
       (keyword_select)
       (select_expression
         (term
-          (field
-            (identifier)))
+          value: (field
+            name: (identifier)))
         (term
-          (window_function
+          value: (window_function
             (invocation
-              (identifier)
-              (term
-                (field
-                  (identifier))))
+              (object_reference
+                name: (identifier))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification))
           (keyword_as)
-          (identifier))))
+          alias: (identifier))))
     (from
       (keyword_from)
       (relation
-        (table_reference
-          (identifier))))))
+        (object_reference
+          name: (identifier))))))
 
 ================================================================================
 Window Functions two inline functions
@@ -213,7 +217,8 @@ FROM tab1;
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -229,7 +234,8 @@ FROM tab1;
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -275,7 +281,8 @@ WINDOW window_def AS (PARTITION BY y);
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -284,7 +291,7 @@ WINDOW window_def AS (PARTITION BY y);
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))
     (window_clause
       (keyword_window)
@@ -322,7 +329,8 @@ WINDOW win AS (ORDER BY d)
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -338,7 +346,8 @@ WINDOW win AS (ORDER BY d)
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -398,7 +407,8 @@ FROM
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -428,7 +438,8 @@ FROM
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -450,7 +461,7 @@ FROM
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -485,7 +496,8 @@ FROM
         (term
           value: (window_function
             (invocation
-              name: (identifier)
+              (object_reference
+                name: (identifier))
               parameter: (term
                 value: (field
                   name: (identifier))))
@@ -524,7 +536,7 @@ FROM
     (from
       (keyword_from)
       (relation
-        (table_reference
+        (object_reference
           name: (identifier))))))
 
 ================================================================================
@@ -567,18 +579,19 @@ FROM
       (keyword_select)
       (select_expression
         (term
-          (field
-            (identifier)))
+          value: (field
+            name: (identifier)))
         (term
-          (field
-            (identifier)))
+          value: (field
+            name: (identifier)))
         (term
-          (window_function
+          value: (window_function
             (invocation
-              (identifier)
-              (term
-                (field
-                  (identifier))))
+              (object_reference
+                name: (identifier))
+              parameter: (term
+                value: (field
+                  name: (identifier))))
             (keyword_over)
             (window_specification
               (partition_by
@@ -586,15 +599,15 @@ FROM
                 (keyword_by)
                 (literal)
                 (field
-                  (identifier))
+                  name: (identifier))
                 (parameter)
                 (case
                   (keyword_case)
                   (keyword_when)
                   (binary_expression
-                    (field
-                      (identifier))
-                    (literal))
+                    left: (field
+                      name: (identifier))
+                    right: (literal))
                   (keyword_then)
                   (literal
                     (keyword_true))
@@ -603,37 +616,38 @@ FROM
                     (keyword_false))
                   (keyword_end))
                 (cast
-                  (keyword_cast)
-                  (field
-                    (identifier))
+                  name: (keyword_cast)
+                  parameter: (field
+                    name: (identifier))
                   (keyword_as)
                   (keyword_date))
                 (cast
                   (field
-                    (identifier))
+                    name: (identifier))
                   (keyword_date))
                 (subquery
                   (select
                     (keyword_select)
                     (select_expression
                       (term
-                        (field
-                          (identifier)))))
+                        value: (field
+                          name: (identifier)))))
                   (from
                     (keyword_from)
                     (relation
-                      (table_reference
-                        (identifier)))))
+                      (object_reference
+                        name: (identifier)))))
                 (invocation
-                  (identifier)
-                  (term
-                    (field
-                      (identifier))))
+                  (object_reference
+                    name: (identifier))
+                  parameter: (term
+                    value: (field
+                      name: (identifier))))
                 (binary_expression
-                  (field
-                    (identifier))
-                  (field
-                    (identifier))))
+                  left: (field
+                    name: (identifier))
+                  right: (field
+                    name: (identifier))))
               (order_by
                 (keyword_order)
                 (keyword_by)
@@ -641,7 +655,7 @@ FROM
                   (literal))
                 (order_target
                   (field
-                    (identifier)))
+                    name: (identifier)))
                 (order_target
                   (parameter))
                 (order_target
@@ -649,9 +663,9 @@ FROM
                     (keyword_case)
                     (keyword_when)
                     (binary_expression
-                      (field
-                        (identifier))
-                      (parameter))
+                      left: (field
+                        name: (identifier))
+                      right: (parameter))
                     (keyword_then)
                     (literal
                       (keyword_true))
@@ -661,15 +675,15 @@ FROM
                     (keyword_end)))
                 (order_target
                   (cast
-                    (keyword_cast)
-                    (field
-                      (identifier))
+                    name: (keyword_cast)
+                    parameter: (field
+                      name: (identifier))
                     (keyword_as)
                     (keyword_date)))
                 (order_target
                   (cast
                     (field
-                      (identifier))
+                      name: (identifier))
                     (keyword_date)))
                 (order_target
                   (subquery
@@ -677,30 +691,31 @@ FROM
                       (keyword_select)
                       (select_expression
                         (term
-                          (field
-                            (identifier)))))
+                          value: (field
+                            name: (identifier)))))
                     (from
                       (keyword_from)
                       (relation
-                        (table_reference
-                          (identifier))))))
+                        (object_reference
+                          name: (identifier))))))
                 (order_target
                   (invocation
-                    (identifier)
-                    (term
-                      (field
-                        (identifier)))))
+                    (object_reference
+                      name: (identifier))
+                    parameter: (term
+                      value: (field
+                        name: (identifier)))))
                 (order_target
                   (binary_expression
-                    (field
-                      (identifier))
-                    (field
-                      (identifier))))))))))
+                    left: (field
+                      name: (identifier))
+                    right: (field
+                      name: (identifier))))))))))
     (from
       (keyword_from)
       (relation
-        (table_reference
-          (identifier))))))
+        (object_reference
+          name: (identifier))))))
 
 ================================================================================
 Window function with empty count as aggregation
@@ -719,21 +734,22 @@ FROM tab1
       (keyword_select)
       (select_expression
         (term
-          (window_function
+          value: (window_function
             (invocation
-              (identifier)
-              (all_fields))
+              (object_reference
+                name: (identifier))
+              parameter: (all_fields))
             (keyword_over)
             (window_specification
               (partition_by
                 (keyword_partition)
                 (keyword_by)
                 (field
-                  (identifier)))))
+                  name: (identifier)))))
           (keyword_as)
-          (identifier))))
+          alias: (identifier))))
     (from
       (keyword_from)
       (relation
-        (table_reference
-          (identifier))))))
+        (object_reference
+          name: (identifier))))))

--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -292,17 +292,17 @@ WINDOW window_def AS (PARTITION BY y);
       (keyword_from)
       (relation
         (object_reference
-          name: (identifier))))
-    (window_clause
-      (keyword_window)
-      (identifier)
-      (keyword_as)
-      (window_specification
-        (partition_by
-          (keyword_partition)
-          (keyword_by)
-          (field
-            name: (identifier)))))))
+          name: (identifier)))
+      (window_clause
+        (keyword_window)
+        (identifier)
+        (keyword_as)
+        (window_specification
+          (partition_by
+            (keyword_partition)
+            (keyword_by)
+            (field
+              name: (identifier))))))))
 
 ================================================================================
 Window Functions one inlined one named
@@ -311,7 +311,7 @@ Window Functions one inlined one named
 SELECT
   a,
   SUM(b) OVER (PARTITION BY c) AS w1,
-  AVG(b) OVER win AS w2,
+  AVG(b) OVER win AS w2
 FROM tab1
 WINDOW win AS (ORDER BY d)
 ;
@@ -354,22 +354,23 @@ WINDOW win AS (ORDER BY d)
             (keyword_over)
             (identifier))
           (keyword_as)
-          alias: (identifier))
-        (term
-          value: (field
-            name: (identifier))
           alias: (identifier))))
-    (window_clause
-      (keyword_window)
-      (identifier)
-      (keyword_as)
-      (window_specification
-        (order_by
-          (keyword_order)
-          (keyword_by)
-          (order_target
-            (field
-              name: (identifier))))))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          name: (identifier)))
+      (window_clause
+        (keyword_window)
+        (identifier)
+        (keyword_as)
+        (window_specification
+          (order_by
+            (keyword_order)
+            (keyword_by)
+            (order_target
+              (field
+                name: (identifier)))))))))
 
 ================================================================================
 Window Functions partition order frame


### PR DESCRIPTION
Incorporates #149 ; not ready for primetime yet, there are four test failures that mostly stem from incorrect precedence negotiation between `object_reference` and `field` -- give it a whirl if you have time!

@matthias-Q if this is too much (it's a lot) you can avoid a lot of the precedence-setting in #149 by setting it in `parametric_type` as here. It still wants the precedence on `relation` but I haven't gone too far down that rabbit hole yet.