### PR TITLE
fix: distinct and order by in invocation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1940,7 +1940,15 @@ module.exports = grammar({
 
     invocation: $ => seq(
       field('name', $.identifier),
-      paren_list(field('parameter', $._select_expression)),
+      paren_list(
+        seq(
+          optional($.keyword_distinct),
+          field(
+            'parameter',
+            $._select_expression,
+          ),
+          optional($.order_by)
+        )),
     ),
 
     exists: $ => seq(
@@ -2241,11 +2249,11 @@ module.exports = grammar({
       $._expression,
     ),
 
-    order_by: $ => seq(
+    order_by: $ => prec.right(seq(
       $.keyword_order,
       $.keyword_by,
       comma_list($.order_target, true),
-    ),
+    )),
 
     order_target: $ => seq(
       $._expression,

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -168,12 +168,16 @@ FROM table_a;
         (term
           value: (invocation
             name: (identifier)
+            (keyword_distinct)
             parameter: (term
               value: (field
-                name: (identifier))
-              alias: (identifier))
-            (ERROR
-              (keyword_by))))))
+                name: (identifier)))
+            (order_by
+              (keyword_order)
+              (keyword_by)
+              (order_target
+                (field
+                  name: (identifier))))))))
     (from
       (keyword_from)
       (relation

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -474,10 +474,10 @@ FROM my_table;
         (term
           value: (invocation
             name: (identifier)
+            (keyword_distinct)
             parameter: (term
               value: (field
-                name: (identifier))
-              alias: (identifier)))
+                name: (identifier))))
           (keyword_as)
           alias: (identifier))))
     (from
@@ -727,12 +727,10 @@ FROM my_table;
         (term
           value: (invocation
             name: (identifier)
+            (keyword_distinct)
             parameter: (term
-              value: (invocation
-                name: (identifier)
-                parameter: (term
-                  value: (field
-                    name: (identifier)))))))))
+              value: (field
+                name: (identifier)))))))
     (from
       (keyword_from)
       (relation
@@ -778,10 +776,10 @@ FROM my_table;
         (term
           value: (invocation
             name: (identifier)
+            (keyword_distinct)
             parameter: (term
               value: (field
-                name: (identifier))
-              alias: (identifier))))))
+                name: (identifier)))))))
     (from
       (keyword_from)
       (relation


### PR DESCRIPTION
Closes #154 

Distinct has been misidentified as a field. The pg specific `order by` was not working at all (we had a test for that)

@DerekStride should we add a CI test that checks for `ERROR` in the tests? (excluding error.txt) to avoid this from happening again?