### PR TITLE
fix: `group_concat` on impala

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1928,7 +1928,10 @@ module.exports = grammar({
       field('name', $.keyword_group_concat),
       '(',
       $._aggregate_expression,
-      optional(seq($.keyword_separator, alias($._literal_string, $.literal))),
+      optional(seq(
+        choice($.keyword_separator, ','),
+        alias($._literal_string, $.literal)
+      )),
       ')',
     ),
 

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -218,6 +218,38 @@ GROUP BY some_field;
           (identifier))))))
 
 ================================================================================
+GROUP CONCAT Impala
+================================================================================
+
+SELECT GROUP_CONCAT(uid, ",")
+FROM some_table
+GROUP BY some_field;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (group_concat
+            (keyword_group_concat)
+            (field
+              (identifier))
+            (literal)))))
+    (from
+      (keyword_from)
+      (relation
+        (table_reference
+          (identifier)))
+      (group_by
+        (keyword_group)
+        (keyword_by)
+        (field
+          (identifier))))))
+
+================================================================================
 GROUP CONCAT with all optional fields
 ================================================================================
 


### PR DESCRIPTION
`group_concat` is slightly different on impala. Instead of the keyword `separator` the sep char is written after a comma.


I am not happy with the fact that we have invocation and this second line of _aggregate_functions. Imo they should be also invocations but might be difficult to add every variant of `invocations`

Closes #158 