### PR TITLE
feat: add `filter` to `aggregate_functions`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -99,6 +99,7 @@ module.exports = grammar({
     keyword_as: _ => make_keyword("as"),
     keyword_distinct: _ => make_keyword("distinct"),
     keyword_constraint: _ => make_keyword("constraint"),
+    keyword_filter: _ => make_keyword("filter"),
     keyword_cast: _ => make_keyword("cast"),
     keyword_separator: _ => make_keyword("separator"),
     keyword_max: _ => make_keyword("max"),
@@ -1927,6 +1928,13 @@ module.exports = grammar({
       ')',
     ),
 
+    filter_expression : $ => seq(
+      $.keyword_filter,
+      '(',
+      $.where,
+      ')',
+    ),
+
     invocation: $ => prec(1,
       seq(
         $.object_reference,
@@ -1956,6 +1964,9 @@ module.exports = grammar({
             ')',
           ),
         ),
+        optional(
+          $.filter_expression
+        )
       ),
     ),
 

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -2668,3 +2668,40 @@ parenthesized select
       (select_expression
         (term
           (literal))))))
+
+================================================================================
+Select with filtered aggregation
+================================================================================
+
+SELECT
+    count(*) FILTER (WHERE i < 5) AS filtered
+FROM tab
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (invocation
+            (object_reference
+              (identifier))
+            (term
+              (all_fields))
+            (filter_expression
+              (keyword_filter)
+              (where
+                (keyword_where)
+                (binary_expression
+                  (field
+                    (identifier))
+                  (literal)))))
+          (keyword_as)
+          (identifier))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          (identifier))))))


### PR DESCRIPTION
I am not sure if the `filter_expression` should be inside the choice node our outside. Currently, a normal invocation can be followed by the `filter_expression`. (which is probably fine.)

Closes #167 