### PR TITLE
feat: nested common table expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -598,15 +598,14 @@ module.exports = grammar({
       optional(
         seq(
           optional($.keyword_not),
-          $.keyword_materialized),
+          $.keyword_materialized,
+        ),
       ),
       '(',
       alias(
         choice(
-          $._select_statement,
-          $._delete_statement,
-          $._insert_statement,
-          $._update_statement,
+          $._dml_read,
+          $._dml_write,
         ),
         $.statement,
       ),

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -277,3 +277,85 @@ FROM top_cte;
    (relation
     (object_reference
      (identifier))))))
+
+================================================================================
+Nested deeper
+================================================================================
+
+WITH top_cte AS (
+  WITH nested_cte AS (
+    WITH nested_further AS (
+      SELECT 1 as one, 2 as two
+    )
+    SELECT * FROM nested_further
+  )
+  SELECT one, two
+  FROM nested_cte
+)
+SELECT *
+FROM top_cte;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (keyword_with)
+  (cte
+   (identifier)
+   (keyword_as)
+   (statement
+    (keyword_with)
+    (cte
+     (identifier)
+     (keyword_as)
+     (statement
+      (keyword_with)
+      (cte
+       (identifier)
+       (keyword_as)
+       (statement
+        (select
+         (keyword_select)
+         (select_expression
+          (term
+           (literal)
+           (keyword_as)
+           (identifier))
+          (term
+           (literal)
+           (keyword_as)
+           (identifier))))))
+      (select
+       (keyword_select)
+       (select_expression
+        (term
+         (all_fields))))
+  (from
+   (keyword_from)
+   (relation
+    (object_reference
+     (identifier))))))
+  (select
+   (keyword_select)
+   (select_expression
+    (term
+     (field
+      (identifier)))
+    (term
+     (field
+      (identifier)))))
+  (from
+   (keyword_from)
+   (relation
+    (object_reference
+     (identifier))))))
+  (select
+   (keyword_select)
+   (select_expression
+    (term
+     (all_fields))))
+  (from
+   (keyword_from)
+   (relation
+    (object_reference
+     (identifier))))))

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -213,3 +213,67 @@ Parenthesized CTE
       (relation
         (object_reference
           (identifier))))))
+
+================================================================================
+Nested CTE
+================================================================================
+
+WITH top_cte AS (
+  WITH nested_cte AS (
+    SELECT 1 as one, 2 as two
+  )
+  SELECT one, two
+  FROM nested_cte
+)
+SELECT *
+FROM top_cte;
+
+--------------------------------------------------------------------------------
+
+(program
+ (statement
+  (keyword_with)
+  (cte
+   (identifier)
+   (keyword_as)
+   (statement
+    (keyword_with)
+    (cte
+     (identifier)
+     (keyword_as)
+     (statement
+      (select
+       (keyword_select)
+       (select_expression
+        (term
+         (literal)
+         (keyword_as)
+         (identifier))
+        (term
+         (literal)
+         (keyword_as)
+         (identifier))))))
+    (select
+     (keyword_select)
+     (select_expression
+      (term
+       (field
+        (identifier)))
+      (term
+       (field
+        (identifier)))))
+  (from
+   (keyword_from)
+   (relation
+    (object_reference
+     (identifier))))))
+  (select
+   (keyword_select)
+   (select_expression
+    (term
+     (all_fields))))
+  (from
+   (keyword_from)
+   (relation
+    (object_reference
+     (identifier))))))


### PR DESCRIPTION
closes #165

@matthias-Q you were close! `_cte` doesn't work in that position because it doesn't allow for the statement that has to follow the with (....) expression.