### PR TITLE
alternative implementation using binary_expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2318,20 +2318,8 @@ module.exports = grammar({
         $.array,
         $.interval,
         $.between_expression,
-        $.json_traversal,
         seq("(", $._expression, ")"),
       )
-    ),
-
-    json_traversal: $ => seq(
-      $._expression,
-      choice(
-        '->',
-        '->>',
-        '#>',
-        '#>>',
-      ),
-      $._literal_string,
     ),
 
     binary_expression: $ => choice(
@@ -2350,6 +2338,10 @@ module.exports = grammar({
         ['>=', 'binary_relation'],
         ['>', 'binary_relation'],
         ['<>', 'binary_relation'],
+        ['->', 'binary_relation'],
+        ['->>', 'binary_relation'],
+        ['#>', 'binary_relation'],
+        ['#>>', 'binary_relation'],
         [$.keyword_is, 'binary_is'],
         [$.is_not, 'binary_is'],
         [$.keyword_like, 'pattern_matching'],

--- a/test/corpus/json.txt
+++ b/test/corpus/json.txt
@@ -13,35 +13,42 @@ FROM users;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (select
-   (keyword_select)
-   (select_expression
-    (term
-     (json_traversal
-      (literal))
-     (keyword_as)
-     (identifier))
-    (term
-     (json_traversal
-      (json_traversal
-       (literal))))
-    (term
-     (json_traversal
-      (json_traversal
-       (literal)))
-     (keyword_as)
-     (identifier))
-    (term
-     (json_traversal
-      (literal)))
-    (term
-     (json_traversal
-      (literal))
-      (keyword_as)
-      (identifier))))
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (binary_expression
+            left: (literal)
+            right: (literal))
+          (keyword_as)
+          alias: (identifier))
+        (term
+          value: (binary_expression
+            left: (binary_expression
+              left: (literal)
+              right: (literal))
+            right: (literal)))
+        (term
+          value: (binary_expression
+            left: (binary_expression
+              left: (literal)
+              right: (literal))
+            right: (literal))
+          (keyword_as)
+          alias: (identifier))
+        (term
+          value: (binary_expression
+            left: (literal)
+            right: (literal)))
+        (term
+          value: (binary_expression
+            left: (literal)
+            right: (literal))
+          (keyword_as)
+          alias: (identifier))))
     (from
-     (keyword_from)
-     (relation
-      (object_reference
-       (identifier))))))
+      (keyword_from)
+      (relation
+        (object_reference
+          name: (identifier))))))


### PR DESCRIPTION
Alternative to #170 that uses the `binary_expression` node.

```
➜ tree-sitter-sql tree-sitter parse tmp/json.sql
(program [0, 0] - [7, 0]
  (statement [0, 0] - [6, 10]
    (select [0, 0] - [5, 35]
      (keyword_select [0, 0] - [0, 6])
      (select_expression [1, 4] - [5, 35]
        (term [1, 4] - [1, 29]
          value: (binary_expression [1, 4] - [1, 20]
            left: (literal [1, 4] - [1, 10])
            right: (literal [1, 13] - [1, 20]))
          (keyword_as [1, 21] - [1, 23])
          alias: (identifier [1, 24] - [1, 29]))
        (term [2, 4] - [2, 32]
          value: (binary_expression [2, 4] - [2, 32]
            left: (binary_expression [2, 4] - [2, 21]
              left: (literal [2, 4] - [2, 10])
              right: (literal [2, 12] - [2, 21]))
            right: (literal [2, 26] - [2, 32])))
        (term [3, 4] - [3, 46]
          value: (binary_expression [3, 4] - [3, 33]
            left: (binary_expression [3, 4] - [3, 21]
              left: (literal [3, 4] - [3, 10])
              right: (literal [3, 12] - [3, 21]))
            right: (literal [3, 26] - [3, 33]))
          (keyword_as [3, 34] - [3, 36])
          alias: (identifier [3, 37] - [3, 46]))
        (term [4, 4] - [4, 21]
          value: (binary_expression [4, 4] - [4, 21]
            left: (literal [4, 4] - [4, 10])
            right: (literal [4, 14] - [4, 21])))
        (term [5, 4] - [5, 35]
          value: (binary_expression [5, 4] - [5, 27]
            left: (literal [5, 4] - [5, 10])
            right: (literal [5, 15] - [5, 27]))
          (keyword_as [5, 28] - [5, 30])
          alias: (identifier [5, 31] - [5, 35]))))
    (from [6, 0] - [6, 10]
      (keyword_from [6, 0] - [6, 4])
      (relation [6, 5] - [6, 10]
        (object_reference [6, 5] - [6, 10]
          name: (identifier [6, 5] - [6, 10]))))))
```