### PR TITLE
feat: tsql multiple add columns in alter statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1131,6 +1131,8 @@ module.exports = grammar({
       $.change_ownership,
     ),
 
+    // TODO: optional `keyword_add` is necessary to allow for chained alter statements in t-sql
+    // maybe needs refactoring
     add_column: $ => seq(
       optional($.keyword_add),
       optional(

--- a/grammar.js
+++ b/grammar.js
@@ -1132,7 +1132,7 @@ module.exports = grammar({
     ),
 
     add_column: $ => seq(
-      $.keyword_add,
+      optional($.keyword_add),
       optional(
         $.keyword_column,
       ),
@@ -1143,7 +1143,7 @@ module.exports = grammar({
 
     add_constraint: $ => seq(
       $.keyword_add,
-      $.keyword_constraint,
+      optional($.keyword_constraint),
       $.identifier,
       $.constraint,
     ),

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -425,7 +425,6 @@ Alter table and multiple
 ALTER TABLE IF EXISTS my_table
   ADD COLUMN IF NOT EXISTS val4 DATE,
   ALTER COLUMN val5 DROP NOT NULL, -- comment, ignore me!
-  RENAME COLUMN val6 TO val7,
   DROP COLUMN IF EXISTS val8;
 
 --------------------------------------------------------------------------------
@@ -456,12 +455,6 @@ ALTER TABLE IF EXISTS my_table
         (keyword_not)
         (keyword_null))
       (comment)
-      (rename_column
-        (keyword_rename)
-        (keyword_column)
-        old_name: (identifier)
-        (keyword_to)
-        new_name: (identifier))
       (drop_column
         (keyword_drop)
         (keyword_column)
@@ -626,3 +619,45 @@ new_table TO old_table;
     (keyword_to)
     (object_reference
       (identifier))))
+
+================================================================================
+T-SQL: alter table add multiple columns at once
+================================================================================
+
+ALTER TABLE tab
+ADD
+col1 VARCHAR(255) NOT NULL DEFAULT('EMPTY'),
+col2 VARCHAR(255) NOT NULL DEFAULT('EMPTY');
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (alter_table
+      (keyword_alter)
+      (keyword_table)
+      (object_reference
+        (identifier))
+      (add_column
+        (keyword_add)
+        (column_definition
+          (identifier)
+          (varchar
+            (keyword_varchar)
+            (literal))
+          (keyword_not)
+          (keyword_null)
+          (keyword_default)
+          (list
+            (literal))))
+      (add_column
+        (column_definition
+          (identifier)
+          (varchar
+            (keyword_varchar)
+            (literal))
+          (keyword_not)
+          (keyword_null)
+          (keyword_default)
+          (list
+            (literal)))))))


### PR DESCRIPTION
Closes #135 and supersedes #144

I feel this is a bit hacky, but I just made the `add` keyword optional, so that it will not repeated in `_alter_specifications`

I also removed that `rename` part of the test, since this is not valid SQL syntax and made the keyword `constrain` optional. See discussion in #144