### PR TITLE
Add bindings & Package.swift to gh-pages build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 18
       - run: npm install
       - name: Publish parser on GitHub Pages
-        run: cp -r src docs
+        run: cp -r src bindings Package.swift docs
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.0


### PR DESCRIPTION
## What

Alternative to https://github.com/DerekStride/tree-sitter-sql/pull/172

This allows swift & other projects that depend on the `bindings/` being present to function without generating them from the `main` branch.

cc// @bombardier200 @mattmassicotte