### PR TITLE
Update unions with named node & allow more optional paranthesis

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -550,13 +550,8 @@ module.exports = grammar({
     statement: $ => seq(
       choice(
         $._ddl_statement,
-        $._dml_read,
         $._dml_write,
-        seq(
-          '(',
-          $._dml_read,
-          ')',
-        ),
+        optional_parenthesis($._dml_read),
       ),
     ),
 
@@ -1700,15 +1695,8 @@ module.exports = grammar({
     ),
 
     _default_expression: $ => seq(
-        $.keyword_default,
-            choice(
-            seq(
-                '(',
-                    $._inner_default_expression,
-                ')',
-            ),
-            $._inner_default_expression,
-        )
+      $.keyword_default,
+      optional_parenthesis($._inner_default_expression),
     ),
     _inner_default_expression: $ => choice(
         $.literal,

--- a/grammar.js
+++ b/grammar.js
@@ -588,7 +588,7 @@ module.exports = grammar({
     ),
 
     _dml_read: $ => seq(
-      optional($._cte),
+      optional(optional_parenthesis($._cte)),
       optional_parenthesis(
         choice(
           $._select_statement,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -165,12 +165,9 @@
   (keyword_to)
   (keyword_schema)
   (keyword_owner)
-  (keyword_union)
   (keyword_all)
   (keyword_any)
   (keyword_some)
-  (keyword_except)
-  (keyword_intersect)
   (keyword_returning)
   (keyword_begin)
   (keyword_commit)
@@ -314,6 +311,9 @@
   (keyword_by)
   (keyword_on)
   (keyword_do)
+  (keyword_union)
+  (keyword_except)
+  (keyword_intersect)
 ] @keyword.operator
 
 [

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -1232,22 +1232,23 @@ UNION ALL
         (identifier))
       (keyword_as)
       (create_query
-        (select
-          (keyword_select)
-          (select_expression
-            (term
-              (literal)
-              (keyword_as)
-              (identifier))))
-        (keyword_union)
-        (keyword_all)
-        (select
-          (keyword_select)
-          (select_expression
-            (term
-              (literal)
-              (keyword_as)
-              (identifier))))))))
+        (set_operation
+          (select
+            (keyword_select)
+            (select_expression
+              (term
+                (literal)
+                (keyword_as)
+                (identifier))))
+          (keyword_union)
+          (keyword_all)
+          (select
+            (keyword_select)
+            (select_expression
+              (term
+                (literal)
+                (keyword_as)
+                (identifier)))))))))
 
 ================================================================================
 Create view as select with cte

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -467,3 +467,81 @@ UNION
         (relation
           (object_reference
             (identifier)))))))
+
+================================================================================
+Parenthesis around CTE
+================================================================================
+
+(
+  with x as (select * from ints)
+)
+(select * from x);
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (keyword_with)
+    (cte
+      (identifier)
+      (keyword_as)
+      (statement
+        (select
+          (keyword_select)
+          (select_expression
+            (term
+              (all_fields))))
+        (from
+          (keyword_from)
+          (relation
+            (object_reference
+              (identifier))))))
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (all_fields))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          (identifier))))))
+
+================================================================================
+Parenthesis around everything
+================================================================================
+
+(
+  (with x as (select * from ints))
+  (select * from x)
+);
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (keyword_with)
+    (cte
+      (identifier)
+      (keyword_as)
+      (statement
+        (select
+          (keyword_select)
+          (select_expression
+            (term
+              (all_fields))))
+        (from
+          (keyword_from)
+          (relation
+            (object_reference
+              (identifier))))))
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (all_fields))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          (identifier))))))

--- a/test/corpus/cte.txt
+++ b/test/corpus/cte.txt
@@ -231,52 +231,52 @@ FROM top_cte;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (keyword_with)
-  (cte
-   (identifier)
-   (keyword_as)
-   (statement
+  (statement
     (keyword_with)
     (cte
-     (identifier)
-     (keyword_as)
-     (statement
-      (select
-       (keyword_select)
-       (select_expression
-        (term
-         (literal)
-         (keyword_as)
-         (identifier))
-        (term
-         (literal)
-         (keyword_as)
-         (identifier))))))
+      (identifier)
+      (keyword_as)
+      (statement
+        (keyword_with)
+        (cte
+          (identifier)
+          (keyword_as)
+          (statement
+            (select
+              (keyword_select)
+              (select_expression
+                (term
+                  (literal)
+                  (keyword_as)
+                  (identifier))
+                (term
+                  (literal)
+                  (keyword_as)
+                  (identifier))))))
+        (select
+          (keyword_select)
+          (select_expression
+            (term
+              (field
+                (identifier)))
+            (term
+              (field
+                (identifier)))))
+        (from
+          (keyword_from)
+          (relation
+            (object_reference
+              (identifier))))))
     (select
-     (keyword_select)
-     (select_expression
-      (term
-       (field
-        (identifier)))
-      (term
-       (field
-        (identifier)))))
-  (from
-   (keyword_from)
-   (relation
-    (object_reference
-     (identifier))))))
-  (select
-   (keyword_select)
-   (select_expression
-    (term
-     (all_fields))))
-  (from
-   (keyword_from)
-   (relation
-    (object_reference
-     (identifier))))))
+      (keyword_select)
+      (select_expression
+        (term
+          (all_fields))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          (identifier))))))
 
 ================================================================================
 Nested deeper
@@ -298,64 +298,172 @@ FROM top_cte;
 --------------------------------------------------------------------------------
 
 (program
- (statement
-  (keyword_with)
-  (cte
-   (identifier)
-   (keyword_as)
-   (statement
+  (statement
     (keyword_with)
     (cte
-     (identifier)
-     (keyword_as)
-     (statement
-      (keyword_with)
-      (cte
-       (identifier)
-       (keyword_as)
-       (statement
+      (identifier)
+      (keyword_as)
+      (statement
+        (keyword_with)
+        (cte
+          (identifier)
+          (keyword_as)
+          (statement
+            (keyword_with)
+            (cte
+              (identifier)
+              (keyword_as)
+              (statement
+                (select
+                  (keyword_select)
+                  (select_expression
+                    (term
+                      (literal)
+                      (keyword_as)
+                      (identifier))
+                    (term
+                      (literal)
+                      (keyword_as)
+                      (identifier))))))
+            (select
+              (keyword_select)
+              (select_expression
+                (term
+                  (all_fields))))
+            (from
+              (keyword_from)
+              (relation
+                (object_reference
+                  (identifier))))))
         (select
-         (keyword_select)
-         (select_expression
-          (term
-           (literal)
-           (keyword_as)
-           (identifier))
-          (term
-           (literal)
-           (keyword_as)
-           (identifier))))))
-      (select
-       (keyword_select)
-       (select_expression
+          (keyword_select)
+          (select_expression
+            (term
+              (field
+                (identifier)))
+            (term
+              (field
+                (identifier)))))
+        (from
+          (keyword_from)
+          (relation
+            (object_reference
+              (identifier))))))
+    (select
+      (keyword_select)
+      (select_expression
         (term
-         (all_fields))))
-  (from
-   (keyword_from)
-   (relation
-    (object_reference
-     (identifier))))))
-  (select
-   (keyword_select)
-   (select_expression
-    (term
-     (field
-      (identifier)))
-    (term
-     (field
-      (identifier)))))
-  (from
-   (keyword_from)
-   (relation
-    (object_reference
-     (identifier))))))
-  (select
-   (keyword_select)
-   (select_expression
-    (term
-     (all_fields))))
-  (from
-   (keyword_from)
-   (relation
-    (object_reference
-     (identifier))))))
+          (all_fields))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          (identifier))))))
+
+================================================================================
+CTE with parenthesized unions
+================================================================================
+
+with tb2 as (
+  SELECT * FROM tb1
+)
+(
+  (SELECT * FROM tb2)
+  UNION
+  (SELECT * FROM tb2)
+)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (keyword_with)
+    (cte
+      (identifier)
+      (keyword_as)
+      (statement
+        (select
+          (keyword_select)
+          (select_expression
+            (term
+              (all_fields))))
+        (from
+          (keyword_from)
+          (relation
+            (object_reference
+              (identifier))))))
+    (set_operation
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            (identifier))))
+      (keyword_union)
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            (identifier)))))))
+
+================================================================================
+CTE with unions
+================================================================================
+
+with tb2 as (
+  SELECT * FROM tb1
+)
+(SELECT * FROM tb2)
+UNION
+(SELECT * FROM tb2)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (keyword_with)
+    (cte
+      (identifier)
+      (keyword_as)
+      (statement
+        (select
+          (keyword_select)
+          (select_expression
+            (term
+              (all_fields))))
+        (from
+          (keyword_from)
+          (relation
+            (object_reference
+              (identifier))))))
+    (set_operation
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            (identifier))))
+      (keyword_union)
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            (identifier)))))))

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -1746,18 +1746,91 @@ SELECT 1 UNION ALL SELECT 2;
 
 (program
   (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          (literal))))
-    (keyword_union)
-    (keyword_all)
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          (literal))))))
+    (set_operation
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (literal))))
+      operation: (keyword_union)
+      operation: (keyword_all)
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (literal)))))))
+
+================================================================================
+Union with parenthesis
+================================================================================
+
+(SELECT * FROM tb2)
+UNION
+(SELECT * FROM tb2)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (set_operation
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            name: (identifier))))
+      operation: (keyword_union)
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            name: (identifier)))))))
+
+================================================================================
+Union with many parenthesis
+================================================================================
+
+(
+ (SELECT * FROM tb2)
+ UNION
+ (SELECT * FROM tb2)
+)
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (set_operation
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            name: (identifier))))
+      operation: (keyword_union)
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (all_fields))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            name: (identifier)))))))
 
 ================================================================================
 Intersect
@@ -1771,29 +1844,30 @@ SELECT b FROM two;
 
 (program
   (statement
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          (field
-            (identifier)))))
-    (from
-      (keyword_from)
-      (relation
-        (object_reference
-          (identifier))))
-    (keyword_intersect)
-    (select
-      (keyword_select)
-      (select_expression
-        (term
-          (field
-            (identifier)))))
-    (from
-      (keyword_from)
-      (relation
-        (object_reference
-          (identifier))))))
+    (set_operation
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (field
+              name: (identifier)))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            name: (identifier))))
+      operation: (keyword_intersect)
+      (select
+        (keyword_select)
+        (select_expression
+          (term
+            value: (field
+              name: (identifier)))))
+      (from
+        (keyword_from)
+        (relation
+          (object_reference
+            name: (identifier)))))))
 
 ================================================================================
 Simple CASE

--- a/test/highlight/union.sql
+++ b/test/highlight/union.sql
@@ -1,0 +1,16 @@
+(SELECT * FROM tb2)
+-- <- punctuation.bracket
+-- ^ keyword
+     -- ^ operator
+       -- ^ keyword
+            -- ^ type
+               -- ^ punctuation.bracket
+UNION
+-- ^ keyword.operator
+(SELECT * FROM tb2)
+-- <- punctuation.bracket
+-- ^ keyword
+     -- ^ operator
+       -- ^ keyword
+            -- ^ type
+               -- ^ punctuation.bracket


### PR DESCRIPTION
## What

fixes https://github.com/DerekStride/tree-sitter-sql/issues/176

Commits might be easier to review separately

* New `optional_parenthesis` & `wrapped_in_parenthesis` functions to make it easier work with parenthesis
* Alias custom `create_query` node with `_dml_read`
* New ~`union` & `intersection`~ `set_operation` node instead of having custom rules in `_select_statement`