### PR TITLE
Allow expr in `generated always` statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -264,6 +264,7 @@ module.exports = grammar({
     // Hive Keywords
     keyword_external: _ => make_keyword("external"),
     keyword_stored: _ => make_keyword("stored"),
+    keyword_virtual: _ => make_keyword("virtual"),
     keyword_cached: _ => make_keyword("cached"),
     keyword_uncached: _ => make_keyword("uncached"),
     keyword_replication: _ => make_keyword("replication"),
@@ -2190,22 +2191,26 @@ module.exports = grammar({
       alias($._literal_string, $.literal)
     ),
 
-    _column_constraint: $ => choice(
-        choice(
-            $.keyword_null,
-            $._not_null,
-        ),
-        $._default_expression,
-        $._primary_key,
-        $.keyword_auto_increment,
-        $.direction,
-        $._column_comment,
-        seq(
-          optional(seq($.keyword_generated, $.keyword_always)),
-          $.keyword_as,
-          $.identifier,
-        ),
-    ),
+    _column_constraint: $ => prec.left(choice(
+      choice(
+        $.keyword_null,
+        $._not_null,
+      ),
+      $._default_expression,
+      $._primary_key,
+      $.keyword_auto_increment,
+      $.direction,
+      $._column_comment,
+      seq(
+        optional(seq($.keyword_generated, $.keyword_always)),
+        $.keyword_as,
+        $._expression,
+      ),
+      choice(
+        $.keyword_stored,
+        $.keyword_virtual,
+      )
+    )),
 
     _default_expression: $ => seq(
       $.keyword_default,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -206,6 +206,7 @@
   (keyword_uncached)
   (keyword_lines)
   (keyword_stored)
+  (keyword_virtual)
   (keyword_partitioned)
   (keyword_analyze)
   (keyword_explain)

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -1584,7 +1584,15 @@ Create table with generated always
 
 CREATE TABLE "Role" (
   "roleId" bigint generated always as identity,
-  "name" varchar NOT NULL
+  "name" varchar NOT NULL,
+  height_in numeric GENERATED ALWAYS AS (height_cm / 2.54) STORED,
+  item_type_name TEXT GENERATED ALWAYS AS (
+     CASE item_type
+       WHEN 1 THEN 'foo'
+       WHEN 2 THEN 'bar'
+       ELSE 'UNKNOWN'
+     END
+  ) VIRTUAL
 );
 
 --------------------------------------------------------------------------------
@@ -1604,13 +1612,48 @@ CREATE TABLE "Role" (
           (keyword_generated)
           (keyword_always)
           (keyword_as)
-          (identifier))
+          (field
+            name: (identifier)))
         (column_definition
           name: (literal)
           type: (varchar
             (keyword_varchar))
           (keyword_not)
-          (keyword_null))))))
+          (keyword_null))
+        (column_definition
+          name: (identifier)
+          type: (numeric
+            (keyword_numeric))
+          (keyword_generated)
+          (keyword_always)
+          (keyword_as)
+          (binary_expression
+            left: (field
+              name: (identifier))
+            right: (literal))
+          (keyword_stored))
+        (column_definition
+          name: (identifier)
+          type: (keyword_text)
+          (keyword_generated)
+          (keyword_always)
+          (keyword_as)
+          (case
+            (keyword_case)
+            (field
+              name: (identifier))
+            (keyword_when)
+            (literal)
+            (keyword_then)
+            (literal)
+            (keyword_when)
+            (literal)
+            (keyword_then)
+            (literal)
+            (keyword_else)
+            (literal)
+            (keyword_end))
+          (keyword_virtual))))))
 
 ================================================================================
 Inet type

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -837,7 +837,7 @@ CREATE TABLE type_test (
   a_datetime DATETIME,
   a_datetime2 DATETIME2,
   a_datetimeoffset DATETIMEOFFSET,
-  a_smalldatetime SMALLDATE,
+  a_smalldatetime SMALLDATETIME,
   a_time TIME,
   a_timestamp TIMESTAMP,
   a_verbose_timestamp TIMESTAMP WITHOUT TIME ZONE,
@@ -1034,7 +1034,8 @@ CREATE TABLE type_test (
           type: (datetimeoffset
             (keyword_datetimeoffset)))
         (column_definition
-          name: (identifier))
+          name: (identifier)
+          type: (keyword_smalldatetime))
         (column_definition
           name: (identifier)
           type: (time


### PR DESCRIPTION
Fixes #193
Unfortunately, it needs a left precedence to work.

There was also another test condition that was wrong since the last release.