### PR TITLE
Fix ALTER TABLE ... ADD CONSTRAINT ... UNIQUE

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2324,7 +2324,7 @@ module.exports = grammar({
         $.keyword_index,
       ),
       optional(field('name', $.identifier)),
-      paren_list($.identifier, true),
+      $.ordered_columns,
       optional(
         seq(
           $.keyword_references,

--- a/grammar.js
+++ b/grammar.js
@@ -2309,13 +2309,20 @@ module.exports = grammar({
     ),
 
     _key_constraint: $ => seq(
-      optional(
-        choice(
+      choice(
+        seq(
           $.keyword_unique,
-          $.keyword_foreign,
+          optional(
+            choice(
+              $.keyword_index,
+              $.keyword_key,
+              seq($.keyword_nulls, optional($.keyword_not), $.keyword_distinct),
+            ),
+          ),
         ),
+        seq(optional($.keyword_foreign), $.keyword_key, optional($._if_not_exists)),
+        $.keyword_index,
       ),
-      choice($.keyword_key, $.keyword_index),
       optional(field('name', $.identifier)),
       paren_list($.identifier, true),
       optional(

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -556,7 +556,9 @@ FOREIGN KEY ("accountId") REFERENCES "Account" ("accountId") ON DELETE CASCADE;
         (constraint
           (keyword_foreign)
           (keyword_key)
-          (identifier)
+          (ordered_columns
+            (column
+              name: (literal)))
           (keyword_references)
           (object_reference
             name: (identifier))
@@ -1152,7 +1154,9 @@ ON UPDATE SET DEFAULT;
         (constraint
           (keyword_foreign)
           (keyword_key)
-          (identifier)
+          (ordered_columns
+            (column
+              (literal)))
           (keyword_references)
           (object_reference
             (identifier))
@@ -1188,6 +1192,10 @@ ALTER TABLE table_name
         (identifier)
         (constraint
           (keyword_unique)
-          (identifier)
-          (identifier)
-          (identifier))))))
+          (ordered_columns
+            (column
+              (identifier))
+            (column
+              (identifier))
+            (column
+              (identifier))))))))

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -1165,3 +1165,29 @@ ON UPDATE SET DEFAULT;
           (keyword_update)
           (keyword_set)
           (keyword_default))))))
+
+================================================================================
+Add unique constraint
+================================================================================
+
+ALTER TABLE table_name
+    ADD CONSTRAINT constraint_name UNIQUE (col1, col2, col3);
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (alter_table
+      (keyword_alter)
+      (keyword_table)
+      (object_reference
+        (identifier))
+      (add_constraint
+        (keyword_add)
+        (keyword_constraint)
+        (identifier)
+        (constraint
+          (keyword_unique)
+          (identifier)
+          (identifier)
+          (identifier))))))

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -200,14 +200,20 @@ CREATE TABLE my_table (
           (constraint
             (keyword_key)
             name: (identifier)
-            (identifier)
-            (identifier))
+            (ordered_columns
+              (column
+                name: (identifier))
+              (column
+                name: (identifier))))
           (constraint
             (keyword_unique)
             (keyword_key)
             name: (identifier)
-            (identifier)
-            (identifier)))))))
+            (ordered_columns
+              (column
+                name: (identifier))
+              (column
+                name: (identifier)))))))))
 
 ================================================================================
 Create table if not exists
@@ -343,7 +349,9 @@ CREATE TABLE IF NOT EXISTS `addresses` (
           (constraint
             (keyword_key)
             name: (identifier)
-            (identifier)))))))
+            (ordered_columns
+              (column
+                name: (identifier)))))))))
 
 ================================================================================
 Create table with multiple constraints
@@ -413,16 +421,23 @@ CREATE TABLE IF NOT EXISTS `addresses` (
           (constraint
             (keyword_key)
             name: (identifier)
-            (identifier))
+            (ordered_columns
+              (column
+                name: (identifier))))
           (constraint
             (keyword_key)
             name: (identifier)
-            (identifier))
+            (ordered_columns
+              (column
+                name: (identifier))))
           (constraint
             (keyword_key)
             name: (identifier)
-            (identifier)
-            (identifier)))))))
+            (ordered_columns
+              (column
+                name: (identifier))
+              (column
+                name: (identifier)))))))))
 
 ================================================================================
 Debugging
@@ -1153,12 +1168,17 @@ CREATE TABLE some_table(
           (constraint
             (keyword_index)
             name: (identifier)
-            (identifier))
+            (ordered_columns
+              (column
+                name: (identifier))))
           (constraint
             (keyword_index)
             name: (identifier)
-            (identifier)
-            (identifier))))
+            (ordered_columns
+              (column
+                name: (identifier))
+              (column
+                name: (identifier))))))
       (table_option
         (keyword_default)
         (keyword_character)


### PR DESCRIPTION
Make the statement work with postgres syntax while keeping the previous mariadb syntax (which seems to be used in create table only).

Why does `ALTER TABLE "Role" ADD CONSTRAINT "pkRole" PRIMARY KEY ("roleId");` CST has `ordered_columns` while
`ALTER TABLE table_name ADD CONSTRAINT constraint_name UNIQUE (col1, col2, col3);` does not ?