### PR TITLE
fix: The scannar can now scan tag name with any (expected '$') ASCII …

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -63,7 +63,7 @@ char* scan_dollar_string_tag(TSLexer *lexer) {
     return NULL;
   }
 
-  while (iswalpha(lexer->lookahead)) {
+  while (lexer->lookahead != '$' && !lexer->eof(lexer)) {
     tag = add_char(tag, text_size, lexer->lookahead, ++index);
     lexer->advance(lexer, false);
   }

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -1101,3 +1101,43 @@ $a$
         (literal)
         (keyword_end)
         (dollar_quote)))))
+
+================================================================================
+Function body with non alphabetic dollar quoted tags
+================================================================================
+
+create or replace function public.do_stuff()
+  returns trigger
+  language plpgsql
+as $_$
+begin
+  return $.$text$.$;
+end;
+$_$
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (object_reference
+        (identifier)
+        (identifier))
+      (function_arguments)
+      (keyword_returns)
+      (keyword_trigger)
+      (function_language
+        (keyword_language)
+        (identifier))
+      (function_body
+        (keyword_as)
+        (dollar_quote)
+        (keyword_begin)
+        (keyword_return)
+        (literal)
+        (keyword_end)
+        (dollar_quote)))))


### PR DESCRIPTION
…char instead of only letters.