### PR TITLE
fix: Change the parser to require a semicolon in function_body of 1 s…

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1216,7 +1216,7 @@ module.exports = grammar({
         $.keyword_as,
         alias($._dollar_quoted_string_start_tag, $.dollar_quote),
         $._function_body_statement,
-        optional(';'),
+        ';',
         alias($._dollar_quoted_string_end_tag, $.dollar_quote),
       ),
     ),

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -586,7 +586,7 @@ Function details, specified after string body
 
 create or replace function public.fn()
   returns int
-  as $$select 1$$
+  as $$select 1;$$
   language sql
   volatile
   parallel restricted


### PR DESCRIPTION
…tatement.

In order to reduce the number of parser state the grammar are less complient, now the function_body of 1 statement needs to end with a semicolon.

Idealy the parse of the function_body should be done by another parser in regard of the language defined.