### PR TITLE
fix: remove duplicated keyword

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -303,7 +303,6 @@ module.exports = grammar({
     keyword_characteristics: _ => make_keyword("characteristics"),
     keyword_follows: _ => make_keyword("follows"),
     keyword_precedes: _ => make_keyword("precedes"),
-    keyword_definer: _ => make_keyword("definer"),
     keyword_each: _ => make_keyword("each"),
     keyword_instead: _ => make_keyword("instead"),
     keyword_of: _ => make_keyword("of"),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -294,7 +294,6 @@
   (keyword_off)
   (keyword_follows)
   (keyword_precedes)
-  (keyword_definer)
   (keyword_each)
   (keyword_instead)
   (keyword_of)


### PR DESCRIPTION
Fixes CI build fail due to duplicated keyword in highlights.scm and gammar.js

Introduced in #207


I do not quite understand why CI checks where green on the PR and are failing after landing the PR.