### PR TITLE
Add missing scanner.c to README and Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
                 ],
                 sources: [
                     "src/parser.c",
+                    "src/scanner.c",
                 ],
                 publicHeadersPath: "bindings/swift",
                 cSettings: [.headerSearchPath("src")])

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Tree-sitter parsers need to be compiled as a shared-object / dynamic-library, yo
 `-shared` & `-fPIC` flags to your compiler.
 
 ```bash
-cc -shared -fPIC -I./src src/parser.c -o sql.so
+cc -shared -fPIC -I./src src/parser.c src/scanner.c -o sql.so
 ```
 
 ## Features


### PR DESCRIPTION
Prior to this change, a new scanner.c source file had been added to the repository. The Makefile had been updated, but the command in the README was missing the new file.

This change adds the new file to the command in the README, and also updates the Package.swift file to declare it as a source.

I think this PR is just a bugfix following from #203.