### PR TITLE
feat: Add REFERENCES column constraint to CREATE TABLE statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2487,6 +2487,27 @@ module.exports = grammar({
         $.keyword_null,
         $._not_null,
       ),
+      seq(
+        $.keyword_references,
+        $.object_reference,
+        paren_list($.identifier, true),
+        repeat(
+          seq(
+            $.keyword_on,
+            choice($.keyword_delete, $.keyword_update),
+            choice(
+              seq($.keyword_no, $.keyword_action),
+              $.keyword_restrict,
+              $.keyword_cascade,
+              seq(
+                $.keyword_set,
+                choice($.keyword_null, $.keyword_default),
+                  optional(paren_list($.identifier, true))
+              ),
+            ),
+          ),
+        ),
+      ),
       $._default_expression,
       $._primary_key,
       $.keyword_auto_increment,

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -2104,3 +2104,35 @@ CREATE TRIGGER update_at_user AFTER UPDATE OF name ON public."user" EXECUTE FUNC
       (object_reference
         (identifier)
         (identifier)))))
+
+================================================================================
+Create table column REFERENCES constraint
+================================================================================
+
+CREATE TABLE foo (
+	bar int NOT NULL REFERENCES bar(foo) ON DELETE CASCADE
+);
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_table
+      (keyword_create)
+      (keyword_table)
+      (object_reference
+        name: (identifier))
+      (column_definitions
+        (column_definition
+          name: (identifier)
+          type: (int
+            (keyword_int))
+          (keyword_not)
+          (keyword_null)
+          (keyword_references)
+          (object_reference
+            name: (identifier))
+          (identifier)
+          (keyword_on)
+          (keyword_delete)
+          (keyword_cascade))))))


### PR DESCRIPTION
See [postgresql CREATE TABLE docs](https://www.postgresql.org/docs/current/sql-createtable.html)
```
where column_constraint is:

[ CONSTRAINT constraint_name ]
{ NOT NULL |
  NULL |
  CHECK ( expression ) [ NO INHERIT ] |
  DEFAULT default_expr |
  GENERATED ALWAYS AS ( generation_expr ) STORED |
  GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( sequence_options ) ] |
  UNIQUE [ NULLS [ NOT ] DISTINCT ] index_parameters |
  PRIMARY KEY index_parameters |
  REFERENCES reftable [ ( refcolumn ) ] [ MATCH FULL | MATCH PARTIAL | MATCH SIMPLE ]
    [ ON DELETE referential_action ] [ ON UPDATE referential_action ] }
[ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ]
```