### PR TITLE
feat!: Add complex index fields to CREATE INDEX statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1301,6 +1301,35 @@ module.exports = grammar({
       alias($._literal_string, $.literal),
     ),
 
+    _operator_class: $ => seq(
+      field("opclass", $.identifier),
+      optional(
+        field("opclass_parameters", wrapped_in_parenthesis(comma_list($.term)))
+      )
+    ),
+
+    _index_field: $ => seq(
+      choice(
+        field("expression", wrapped_in_parenthesis($._expression)),
+        field("function", $.invocation),
+        field("column", $._column),
+      ),
+      optional(seq($.keyword_collate, $.identifier)),
+      optional($._operator_class),
+      optional($.direction),
+      optional(
+        seq(
+          $.keyword_nulls,
+          choice(
+            $.keyword_first,
+            $.keyword_last
+          )
+        )
+      ),
+    ),
+
+    index_fields: $ => wrapped_in_parenthesis(comma_list(alias($._index_field, $.field))),
+
     create_index: $ => seq(
       $.keyword_create,
       optional($.keyword_unique),
@@ -1329,7 +1358,7 @@ module.exports = grammar({
             ),
           ),
         ),
-        $.ordered_columns,
+        $.index_fields
       ),
       optional(
         $.where,

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -1218,9 +1218,9 @@ CREATE UNIQUE INDEX "akRoleName" ON "Role" ("name");
       (keyword_on)
       (object_reference
         name: (identifier))
-      (ordered_columns
-        (column
-          name: (literal))))))
+      (index_fields
+        (field
+          column: (literal))))))
 
 ================================================================================
 Create table as select

--- a/test/corpus/index.txt
+++ b/test/corpus/index.txt
@@ -14,8 +14,8 @@ CREATE INDEX ON tab(col);
       (keyword_on)
       (object_reference
         (identifier))
-      (ordered_columns
-        (column
+      (index_fields
+        (field
           (identifier))))))
 
 ================================================================================
@@ -45,8 +45,8 @@ WHERE tab.col > 10;
         (identifier))
       (keyword_using)
       (keyword_hash)
-      (ordered_columns
-        (column
+      (index_fields
+        (field
           (identifier)
           (direction
             (keyword_asc))))
@@ -58,3 +58,56 @@ WHERE tab.col > 10;
               (identifier))
             (identifier))
           (literal))))))
+
+================================================================================
+Create unique index with complex index fields
+================================================================================
+
+CREATE UNIQUE INDEX foo_index ON foo (
+	md5(COALESCE(cat, '')) COLLATE some_collation ASC NULLS LAST,
+	dog some_operator_class(1),
+	(cow / 2)
+);
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_index
+      (keyword_create)
+      (keyword_unique)
+      (keyword_index)
+      column: (identifier)
+      (keyword_on)
+      (object_reference
+        name: (identifier))
+      (index_fields
+        (field
+          function: (invocation
+            (object_reference
+              name: (identifier))
+            parameter: (term
+              value: (invocation
+                (object_reference
+                  name: (identifier))
+                parameter: (term
+                  value: (field
+                    name: (identifier)))
+                parameter: (term
+                  value: (literal)))))
+          (keyword_collate)
+          (identifier)
+          (direction
+            (keyword_asc))
+          (keyword_nulls)
+          (keyword_last))
+        (field
+          column: (identifier)
+          opclass: (identifier)
+          opclass_parameters: (term
+            value: (literal)))
+        (field
+          expression: (binary_expression
+            left: (field
+              name: (identifier))
+            right: (literal)))))))


### PR DESCRIPTION
See [postgresql CREATE INDEX docs](https://www.postgresql.org/docs/current/sql-createindex.html)

The CREATE INDEX statement should be able to support three different types of index fields:
1. Column names
2. Expressions (wrapped in parentheses)
3. Function calls

This PR adds those features to the CREATE INDEX statement while preserving backwards compatibility with existing tests/queries. 

There is some code duplication going on here that I couldn't figure out how to resolve; maybe someone has a suggestion for how this can be improved. Each of the three types of index fields takes a set of optional parameters, but I couldn't break them out into their own rule since they are all optional and a rule containing only optional fields would match the empty string rule and therefore be invalid. I also couldn't wrap the three types in a `choice` followed by the optional nodes since the optional nodes need to be children of the `column` node in order to not break existing tests/queries.