### PR TITLE
fix: ensure scanner.c is included in npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ build
 package-lock.json
 /target/
 /.build/
-/src/
+/src/tree_sitter/
+/src/parser.c
+/src/*.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build/test](https://github.com/derekstride/tree-sitter-sql/actions/workflows/ci.yml/badge.svg)](https://github.com/derekstride/tree-sitter-sql/actions/workflows/ci.yml)
 [![GitHub Pages](https://github.com/DerekStride/tree-sitter-sql/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/DerekStride/tree-sitter-sql/actions/workflows/gh-pages.yml)
+[![npm package version](https://img.shields.io/npm/v/%40derekstride/tree-sitter-sql?logo=npm&color=brightgreen)](https://www.npmjs.com/package/@derekstride/tree-sitter-sql)
+
 
 A general/permissive SQL grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 


### PR DESCRIPTION
## What

fixes #231 

> I'm not well versed on the npm publish behavior, but I think this is being caused by [having /src/ defined on .gitignore](https://github.com/DerekStride/tree-sitter-sql/blob/a65f58c364f4051e14c54be06dfdb91b546d6e7f/.gitignore#L12).

[This was the issue](https://docs.npmjs.com/cli/v10/using-npm/developers#keeping-files-out-of-your-package) and updating the `.gitignore` to be more specific solved the issue.

```
$ npm pack --dry-run 2>&1 | rg src
npm notice 4.8kB  src/scanner.c
```