### PR TITLE
fix(scanner): do not allow whitespaces in dollar quote tag

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -64,7 +64,7 @@ char* scan_dollar_string_tag(TSLexer *lexer) {
     return NULL;
   }
 
-  while (lexer->lookahead != '$' && !lexer->eof(lexer)) {
+  while (lexer->lookahead != '$' && !iswspace(lexer->lookahead) && !lexer->eof(lexer)) {
     tag = add_char(tag, text_size, lexer->lookahead, ++index);
     lexer->advance(lexer, false);
   }

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -149,37 +149,43 @@ Function body with a tag name contains whitespace
 create or replace function public.do_stuff()
   returns trigger
   language plpgsql
-as $a $
+as $a$
 begin
-  return $b$text$b$;
+  return $b $text$b $;
 end;
-$a $;
+$a$;
 
 --------------------------------------------------------------------------------
 
 (program
-  (ERROR
-    (keyword_create)
-    (keyword_or)
-    (keyword_replace)
-    (keyword_function)
-    (object_reference
-      (identifier)
-      (identifier))
-    (function_arguments)
-    (keyword_returns)
-    (keyword_trigger)
-    (function_language
-      (keyword_language)
-      (identifier))
-    (ERROR
-      (keyword_as)
-      (UNEXPECTED 'a')
-      (UNEXPECTED '\n'))
-    (keyword_begin)
-    (dollar_quote)
-    (keyword_text)
-    (dollar_quote)
-    (keyword_end)
-    (UNEXPECTED 'a')
-    (UNEXPECTED ';')))
+  (statement
+    (create_function
+      (keyword_create)
+      (keyword_or)
+      (keyword_replace)
+      (keyword_function)
+      (object_reference
+        (identifier)
+        (identifier))
+      (function_arguments)
+      (keyword_returns)
+      (keyword_trigger)
+      (function_language
+        (keyword_language)
+        (identifier))
+      (function_body
+        (keyword_as)
+        (dollar_quote)
+        (keyword_begin)
+        (keyword_return)
+        (ERROR
+          (UNEXPECTED 'b'))
+        (field
+          (identifier))
+        (ERROR
+          (UNEXPECTED 't')
+          (keyword_text)
+          (UNEXPECTED 'b')
+          (UNEXPECTED ';'))
+        (keyword_end)
+        (dollar_quote)))))

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -141,3 +141,45 @@ $c$;
           (UNEXPECTED 'c')
           (UNEXPECTED ';'))
         (MISSING dollar_quote)))))
+
+================================================================================
+Function body with a tag name contains whitespace
+================================================================================
+
+create or replace function public.do_stuff()
+  returns trigger
+  language plpgsql
+as $a $
+begin
+  return $b$text$b$;
+end;
+$a $;
+
+--------------------------------------------------------------------------------
+
+(program
+  (ERROR
+    (keyword_create)
+    (keyword_or)
+    (keyword_replace)
+    (keyword_function)
+    (object_reference
+      (identifier)
+      (identifier))
+    (function_arguments)
+    (keyword_returns)
+    (keyword_trigger)
+    (function_language
+      (keyword_language)
+      (identifier))
+    (ERROR
+      (keyword_as)
+      (UNEXPECTED 'a')
+      (UNEXPECTED '\n'))
+    (keyword_begin)
+    (dollar_quote)
+    (keyword_text)
+    (dollar_quote)
+    (keyword_end)
+    (UNEXPECTED 'a')
+    (UNEXPECTED ';')))


### PR DESCRIPTION
Whitespace characters not allowed in dollar quoted tags.
[docs](https://www.postgresql.org/docs/16/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING):
> The tag, if any, of a dollar-quoted string follows the same rules as an unquoted identifier, except that it cannot contain a dollar sign.

Fixes problems with [sqlc](https://github.com/sqlc-dev/sqlc) queries, which use positional parameters outside function definitions or prepared statements. For example:
```sql
SELECT * FROM a
LIMIT $1 OFFSET $2;

SELECT * FROM b
LIMIT $1 OFFSET $2;
```
`$1 OFFSET $` should not be recognized as a tag name.