### PR TITLE
Fix literal numerics regex highlights

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -34,10 +34,10 @@
 (marginalia) @comment
 
 ((literal) @number
-   (#match? @number "^%d+$"))
+   (#match? @number "^[-+]?%d+$"))
 
 ((literal) @float
-  (#match? @float "^[-|+]?%d*\.%d*$"))
+  (#match? @float "^[-+]?%d*\.%d*$"))
 
 (parameter) @parameter
 


### PR DESCRIPTION
In the migration from `lua-match` to `match` in https://github.com/DerekStride/tree-sitter-sql/commit/e69a1e6c47baeb83b58a564160c310506f59cfc4 you seem to have made some slight errors:

- integers can have signs too

- with `[]` syntax to mean "one of" you don't need the `|` (that's only needed if you use round parentheses `(-|\+)`), now it would match the `|1.2` literal as a float, which seems wrong