### PR TITLE
add: `check constraint` for column definitions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2544,6 +2544,7 @@ module.exports = grammar({
       $.keyword_auto_increment,
       $.direction,
       $._column_comment,
+      $._check_constraint,
       seq(
         optional(seq($.keyword_generated, $.keyword_always)),
         $.keyword_as,
@@ -2554,6 +2555,17 @@ module.exports = grammar({
         $.keyword_virtual,
       )
     )),
+
+    _check_constraint: $ => seq(
+      optional(
+        seq(
+          $.keyword_constraint,
+          $.literal
+        )
+      ),
+      $.keyword_check,
+      wrapped_in_parenthesis($.binary_expression)
+    ),
 
     _default_expression: $ => seq(
       $.keyword_default,
@@ -2583,13 +2595,21 @@ module.exports = grammar({
       $._constraint_literal,
       $._key_constraint,
       $._primary_key_constraint,
+      $._check_constraint
     ),
 
     _constraint_literal: $ => seq(
       $.keyword_constraint,
       field('name', $.identifier),
-      $._primary_key,
-      $.ordered_columns,
+      choice(
+        seq(
+          $._primary_key,
+          $.ordered_columns,
+        ),
+        seq(
+          $._check_constraint
+        )
+      )
     ),
 
     _primary_key_constraint: $ => seq(

--- a/test/corpus/create.txt
+++ b/test/corpus/create.txt
@@ -216,6 +216,62 @@ CREATE TABLE my_table (
                 name: (identifier)))))))))
 
 ================================================================================
+Create table with constraint checks
+================================================================================
+
+CREATE TABLE products (
+    product_no integer,
+    name text,
+    price numeric CHECK (price > 0),
+    discounted_price numeric CHECK (discounted_price > 0),
+    CHECK (price > discounted_price)
+);
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_table
+      (keyword_create)
+      (keyword_table)
+      (object_reference
+        (identifier))
+      (column_definitions
+        (column_definition
+          (identifier)
+          (int
+            (keyword_int)))
+        (column_definition
+          (identifier)
+          (keyword_text))
+        (column_definition
+          (identifier)
+          (numeric
+            (keyword_numeric))
+          (keyword_check)
+          (binary_expression
+            (field
+              (identifier))
+            (literal)))
+        (column_definition
+          (identifier)
+          (numeric
+            (keyword_numeric))
+          (keyword_check)
+          (binary_expression
+            (field
+              (identifier))
+            (literal)))
+        (constraints
+          (constraint
+            (keyword_check)
+            (binary_expression
+              (field
+                (identifier))
+              (field
+                (identifier)))))))))
+
+================================================================================
 Create table if not exists
 ================================================================================
 


### PR DESCRIPTION
fixes #247 


@DerekStride I think I have a newer version of tree-sitter on my machine and I get a bunch of warnings. There was a change about the order of query matches (which breaks the tests) and something related to non static functions in the scanner.c