### PR TITLE
chore: use newer tree-sitter version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.3"
+tree-sitter = ">=0.21.0"
 
 [build-dependencies]
-cc = "1.0"
+cc = "~1.0.90"


### PR DESCRIPTION
Hi ast-grep author here. To use tree-sitter-sql with a newer tree-sitter library, the cargo.toml can be updated. 

I'm using the tree-sitter-javascript as a reference.

https://github.com/tree-sitter/tree-sitter-javascript/blob/master/Cargo.toml

Hope this can help a new release of tree-sitter-sql!