### PR TITLE
chore: update crate name to avoid conflicts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  npm-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,3 +16,14 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  cargo-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tree-sitter-sql"
+name = "tree-sitter-sequel"
 description = "sql grammar for the tree-sitter parsing library"
 version = "0.3.2"
 keywords = ["incremental", "parsing", "sql"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ tar -xzf gh-pages.tar.gz
 cd tree-sitter-sql-gh-pages
 ```
 
+### [Cargo](https://crates.io/crates/tree-sitter-sequel)
+
+```bash
+cargo add tree-sitter-sequel
+```
+
+### [NPM](https://www.npmjs.com/package/@derekstride/tree-sitter-sql)
+
+```bash
+npm i @derekstride/tree-sitter-sql
+```
+
 ### Step 2: Compile the Parser
 
 Tree-sitter parsers need to be compiled as a shared-object / dynamic-library, you can enable this by passing the


### PR DESCRIPTION
## What

I hand published this project under the crate name [tree-sitter-sequel](https://crates.io/crates/tree-sitter-sequel) since `tree-sitter-sql` was already taken.

This PR updates the cargo.toml manifest to reflect the published name & sets up a workflow to automatically publish new versions on release.

cc// @HerringtonDarkholme @alexbit-codemod