### PR TITLE
fix(ci): generate the parser artifacts before cargo publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
## What

The cargo publish workflow failed because the parser files weren't present. By running `npm ci` we force the files to be generated and ensure the test suite passes before publishing the crate.

https://github.com/DerekStride/tree-sitter-sql/actions/runs/10167937438/job/28121386966

## Note

In the meantime I've published v0.3.3 manually: https://crates.io/crates/tree-sitter-sequel