### PR TITLE
feat: publish package to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,3 +32,7 @@ jobs:
       - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  pypi-publish:
+    uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
+    secrets:
+      PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}


### PR DESCRIPTION
## What

Publish package to pypi, part of #269. I'm testing out the [tree-sitter/workflows](https://github.com/tree-sitter/workflows), if it works without the generated parser files being present we can try migrating the other workflows.