### PR TITLE
Publish fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,8 @@ jobs:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   pypi-publish:
     uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
+    with:
+      python-version: 3.11
+      generate: true
     secrets:
       PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Publish Packages
 on:
   release:
     types: [published]
@@ -31,6 +31,7 @@ jobs:
           override: true
       - uses: katyo/publish-crates@v2
         with:
+          args: --allow-dirty
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   pypi-publish:
     uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_sql/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c",
             ],
             extra_compile_args=[
                 "-std=c11",


### PR DESCRIPTION
## What

The cargo & python publish steps didn't work. The cargo step was simple to fix just requiring a `--allow-dirty` flag to be passed to the action.

The python workflow requires a bit of extra work, I've opened a PR on the main workflow repo and changed this repo to reference my branch: https://github.com/tree-sitter/workflows/pull/14