### PR TITLE
tree-sitter 0.23 upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=0.22.0"
+tree-sitter-language = "0.1.0"
 
 [build-dependencies]
 cc = "~1.0.90"
+
+[dev-dependencies]
+tree-sitter = "0.23"

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_sql_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-sql"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_sql "github.com/tree-sitter/tree-sitter-sql/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter/tree-sitter-sql
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -1,0 +1,9 @@
+/// <reference types="node" />
+
+const assert = require("node:assert");
+const { test } = require("node:test");
+
+test("can load grammar", () => {
+  const parser = new (require("tree-sitter"))();
+  assert.doesNotThrow(() => parser.setLanguage(require(".")));
+});

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+import tree_sitter, tree_sitter_sql
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            tree_sitter.Language(tree_sitter_sql.language())
+        except Exception:
+            self.fail("Error loading Sql grammar")

--- a/bindings/python/tree_sitter_sql/binding.c
+++ b/bindings/python/tree_sitter_sql/binding.c
@@ -4,8 +4,8 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_sql(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_sql());
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_sql(), "tree_sitter.Language", NULL);
 }
 
 static PyMethodDef methods[] = {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -36,7 +36,7 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,44 +1,45 @@
-//! This crate provides sql language support for the [tree-sitter][] parsing library.
+//! This crate provides Sql language support for the [tree-sitter][] parsing library.
 //!
-//! Typically, you will use the [language][language func] function to add this language to a
+//! Typically, you will use the [LANGUAGE][] constant to add this language to a
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_sql::language()).expect("Error loading sql grammar");
+//! let language = tree_sitter_sql::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Sql parser");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
-//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_sql() -> Language;
+    fn tree_sitter_sql() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// The tree-sitter [`LanguageFn`][LanguageFn] for this grammar.
 ///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_sql() }
-}
+/// [LanguageFn]: https://docs.rs/tree-sitter-language/*/tree_sitter_language/struct.LanguageFn.html
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_sql) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-// Uncomment these to include any queries that this grammar contains
+// NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -46,7 +47,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
-            .expect("Error loading sql language");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Sql parser");
     }
 }

--- a/bindings/swift/TreeSitterSqlTests/TreeSitterSqlTests.swift
+++ b/bindings/swift/TreeSitterSqlTests/TreeSitterSqlTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterSql
+
+final class TreeSitterSqlTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_sql())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading Sql grammar")
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter/tree-sitter-sql
+
+go 1.23
+
+require github.com/tree-sitter/go-tree-sitter v0.23.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@derekstride/tree-sitter-sql",
-  "version": "0.3.1",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@derekstride/tree-sitter-sql",
-      "version": "0.3.1",
+      "version": "0.3.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "commit-and-tag-version": "^12.0.0",
         "node-gyp": "^10.0.1",
         "prebuildify": "^6.0.0",
-        "tree-sitter-cli": "^0.22.6"
+        "tree-sitter-cli": "^0.23.0"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.0"
@@ -3258,13 +3258,16 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.6.tgz",
-      "integrity": "sha512-s7mYOJXi8sIFkt/nLJSqlYZP96VmKTc3BAwIX0rrrlRxWjWuCwixFqwzxWZBQz4R8Hx01iP7z3cT3ih58BUmZQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
+      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tree-sitter/node_modules/node-addon-api": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
-    "install": "node-gyp-build",
+    "test": "tree-sitter test",
+    "install": "tree-sitter generate && node-gyp-build",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
-    "test": "node --test bindings/node/*_test.js"
+    "release": "commit-and-tag-version",
+    "prebuildify": "prebuildify --napi --strip"
   },
   "author": "derek stride",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
-    "test": "tree-sitter test",
-    "install": "tree-sitter generate && node-gyp-build",
-    "release": "commit-and-tag-version",
-    "prebuildify": "prebuildify --napi --strip"
+    "install": "node-gyp-build",
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "author": "derek stride",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "commit-and-tag-version": "^12.0.0",
     "node-gyp": "^10.0.1",
     "prebuildify": "^6.0.0",
-    "tree-sitter-cli": "^0.22.6"
+    "tree-sitter-cli": "^0.23.0"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.0"


### PR DESCRIPTION
The main motivation for this upgrade is to move the Rust binding to depending on `tree-sitter-language`, which is a much more stable library that simplifies further `tree-sitter` upgrade for Rust projects.

For now, I've restored the `package.json` scripts that were updated by the tool. These can be made upgrade-proof in a separate PR, I think.