### PR TITLE
feat: drop constraint rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1673,6 +1673,7 @@ module.exports = grammar({
     _alter_specifications: $ => choice(
       $.add_column,
       $.add_constraint,
+      $.drop_constraint,
       $.alter_column,
       $.modify_column,
       $.change_column,
@@ -1700,6 +1701,14 @@ module.exports = grammar({
       optional($.keyword_constraint),
       $.identifier,
       $.constraint,
+    ),
+
+    drop_constraint: $ => seq(
+      $.keyword_drop,
+      $.keyword_constraint,
+      optional($._if_exists),
+      $.identifier,
+      optional($._drop_behavior),
     ),
 
     alter_column: $ => seq(

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -534,6 +534,29 @@ ALTER TABLE "Role" ADD CONSTRAINT "pkRole" PRIMARY KEY ("roleId");
               name: (literal))))))))
 
 ================================================================================
+Drop column constraint
+================================================================================
+
+ALTER TABLE posts DROP CONSTRAINT posts_user_id_fkey;
+
+--------------------------------------------------------------------------------
+
+(program
+    (statement
+        (alter_table
+            (keyword_alter)
+            (keyword_table)
+            (object_reference
+                name: (identifier))
+            (drop_constraint
+                (keyword_drop)
+                (keyword_constraint)
+                (identifier))
+        )
+    )
+)
+
+================================================================================
 Add foreign key constraint
 ================================================================================
 


### PR DESCRIPTION
I don't know many sql dialects but such syntax is at least supported by postgresql: 
https://www.postgresql.org/docs/17/sql-altertable.html
> DROP CONSTRAINT [ IF EXISTS ]  constraint_name [ RESTRICT | CASCADE ]

Here's a little visual change:
![image](https://github.com/user-attachments/assets/111046a8-6d9e-4c2f-bd17-bf429b909c55)