### PR TITLE
tree-sitter 0.24 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(tree-sitter-sql
+        VERSION "0.3.5"
+        DESCRIPTION "Tree-sitter Grammar for SQL"
+        HOMEPAGE_URL "git+https://github.com/derekstride/tree-sitter-sql.git"
+        LANGUAGES C)
+
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+option(TREE_SITTER_REUSE_ALLOCATOR "Reuse the library allocator" OFF)
+
+set(TREE_SITTER_ABI_VERSION 14 CACHE STRING "Tree-sitter ABI version")
+if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
+    unset(TREE_SITTER_ABI_VERSION CACHE)
+    message(FATAL_ERROR "TREE_SITTER_ABI_VERSION must be an integer")
+endif()
+
+find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
+
+add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
+                   COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
+                            --abi=${TREE_SITTER_ABI_VERSION}
+                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                   COMMENT "Generating parser.c")
+
+add_library(tree-sitter-sql src/parser.c)
+if(EXISTS src/scanner.c)
+  target_sources(tree-sitter-sql PRIVATE src/scanner.c)
+endif()
+target_include_directories(tree-sitter-sql PRIVATE src)
+
+target_compile_definitions(tree-sitter-sql PRIVATE
+                           $<$<BOOL:${TREE_SITTER_REUSE_ALLOCATOR}>:TREE_SITTER_REUSE_ALLOCATOR>
+                           $<$<CONFIG:Debug>:TREE_SITTER_DEBUG>)
+
+set_target_properties(tree-sitter-sql
+                      PROPERTIES
+                      C_STANDARD 11
+                      POSITION_INDEPENDENT_CODE ON
+                      SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
+                      DEFINE_SYMBOL "")
+
+configure_file(bindings/c/tree-sitter-sql.pc.in
+               "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-sql.pc" @ONLY)
+
+include(GNUInstallDirs)
+
+install(FILES bindings/c/tree-sitter-sql.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-sql.pc"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
+install(TARGETS tree-sitter-sql
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+add_custom_target(test "${TREE_SITTER_CLI}" test
+                  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                  COMMENT "tree-sitter test")
+
+# vim:ft=cmake:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
 name = "tree-sitter-sequel"
-description = "sql grammar for the tree-sitter parsing library"
+description = "Tree-sitter Grammar for SQL"
 version = "0.3.5"
-keywords = ["incremental", "parsing", "sql"]
-categories = ["parsing", "text-editors"]
-repository = "https://github.com/DerekStride/tree-sitter-sql"
-edition = "2018"
+authors = ["derek stride"]
 license = "MIT"
+readme = "README.md"
+keywords = ["incremental", "parsing", "tree-sitter", "sql"]
+categories = ["parsing", "text-editors"]
+repository = "git+https://github.com/derekstride/tree-sitter-sql.git"
+edition = "2021"
+autoexamples = false
 
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
@@ -23,7 +21,7 @@ path = "bindings/rust/lib.rs"
 tree-sitter-language = "0.1"
 
 [build-dependencies]
-cc = "~1.2.1"
+cc = "1.1.22"
 
 [dev-dependencies]
-tree-sitter = "0.23"
+tree-sitter = "0.24.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "bindings/rust/lib.rs"
 tree-sitter-language = "0.1"
 
 [build-dependencies]
-cc = "1.1.22"
+cc = "~1.2.1"
 
 [dev-dependencies]
 tree-sitter = "0.24.3"

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             path: ".",
             sources: [
                 "src/parser.c",
-                // NOTE: if your language has an external scanner, add it here.
+                "src/scanner.c"
             ],
             resources: [
                 .copy("queries")

--- a/Package.swift
+++ b/Package.swift
@@ -1,34 +1,37 @@
 // swift-tools-version:5.3
-
 import PackageDescription
 
 let package = Package(
-    name: "TreeSitterSQL",
-    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    name: "TreeSitterSql",
     products: [
-        .library(name: "TreeSitterSQL", targets: ["TreeSitterSQL"]),
+        .library(name: "TreeSitterSql", targets: ["TreeSitterSql"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/ChimeHQ/SwiftTreeSitter", from: "0.8.0"),
+    ],
     targets: [
-        .target(name: "TreeSitterSQL",
-                path: ".",
-                exclude: [
-                    "binding.gyp",
-                    "bindings",
-                    "Cargo.toml",
-                    "grammar.js",
-                    "LICENSE",
-                    "Makefile",
-                    "package.json",
-                    "README.md",
-                    "src/grammar.json",
-                    "src/node-types.json",
-                ],
-                sources: [
-                    "src/parser.c",
-                    "src/scanner.c",
-                ],
-                publicHeadersPath: "bindings/swift",
-                cSettings: [.headerSearchPath("src")])
-    ]
+        .target(
+            name: "TreeSitterSql",
+            dependencies: [],
+            path: ".",
+            sources: [
+                "src/parser.c",
+                // NOTE: if your language has an external scanner, add it here.
+            ],
+            resources: [
+                .copy("queries")
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("src")]
+        ),
+        .testTarget(
+            name: "TreeSitterSqlTests",
+            dependencies: [
+                "SwiftTreeSitter",
+                "TreeSitterSql",
+            ],
+            path: "bindings/swift/TreeSitterSqlTests"
+        )
+    ],
+    cLanguageStandard: .c11
 )

--- a/bindings/c/tree-sitter-sql.pc.in
+++ b/bindings/c/tree-sitter-sql.pc.in
@@ -1,11 +1,11 @@
-prefix=@PREFIX@
-libdir=@LIBDIR@
-includedir=@INCLUDEDIR@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: tree-sitter-sql
-Description: Sql grammar for tree-sitter
-URL: @URL@
-Version: @VERSION@
-Requires: @REQUIRES@
-Libs: -L${libdir} @ADDITIONAL_LIBS@ -ltree-sitter-sql
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires: @TS_REQUIRES@
+Libs: -L${libdir} -ltree-sitter-sql
 Cflags: -I${includedir}

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_sql "github.com/tree-sitter/tree-sitter-sql/bindings/go"
+	tree_sitter_sql "git+github.com/derekstride/tree-sitter-sql.git/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/node/binding.cc
+++ b/bindings/node/binding.cc
@@ -6,7 +6,7 @@ extern "C" TSLanguage *tree_sitter_sql();
 
 // "tree-sitter", "language" hashed with BLAKE2
 const napi_type_tag LANGUAGE_TYPE_TAG = {
-  0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
+    0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
 };
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {

--- a/bindings/python/tree_sitter_sql/__init__.py
+++ b/bindings/python/tree_sitter_sql/__init__.py
@@ -14,8 +14,8 @@ def _get_query(name, file):
 def __getattr__(name):
     # NOTE: uncomment these to include any queries that this grammar contains:
 
-    # if name == "HIGHLIGHTS_QUERY":
-    #     return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
+    if name == "HIGHLIGHTS_QUERY":
+        return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
     # if name == "INJECTIONS_QUERY":
     #     return _get_query("INJECTIONS_QUERY", "injections.scm")
     # if name == "LOCALS_QUERY":
@@ -28,7 +28,7 @@ def __getattr__(name):
 
 __all__ = [
     "language",
-    # "HIGHLIGHTS_QUERY",
+    "HIGHLIGHTS_QUERY",
     # "INJECTIONS_QUERY",
     # "LOCALS_QUERY",
     # "TAGS_QUERY",

--- a/bindings/python/tree_sitter_sql/__init__.py
+++ b/bindings/python/tree_sitter_sql/__init__.py
@@ -1,5 +1,42 @@
-"Sql grammar for tree-sitter"
+"""Tree-sitter Grammar for SQL"""
+
+from importlib.resources import files as _files
 
 from ._binding import language
 
-__all__ = ["language"]
+
+def _get_query(name, file):
+    query = _files(f"{__package__}.queries") / file
+    globals()[name] = query.read_text()
+    return globals()[name]
+
+
+def __getattr__(name):
+    # NOTE: uncomment these to include any queries that this grammar contains:
+
+    # if name == "HIGHLIGHTS_QUERY":
+    #     return _get_query("HIGHLIGHTS_QUERY", "highlights.scm")
+    # if name == "INJECTIONS_QUERY":
+    #     return _get_query("INJECTIONS_QUERY", "injections.scm")
+    # if name == "LOCALS_QUERY":
+    #     return _get_query("LOCALS_QUERY", "locals.scm")
+    # if name == "TAGS_QUERY":
+    #     return _get_query("TAGS_QUERY", "tags.scm")
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "language",
+    # "HIGHLIGHTS_QUERY",
+    # "INJECTIONS_QUERY",
+    # "LOCALS_QUERY",
+    # "TAGS_QUERY",
+]
+
+
+def __dir__():
+    return sorted(__all__ + [
+        "__all__", "__builtins__", "__cached__", "__doc__", "__file__",
+        "__loader__", "__name__", "__package__", "__path__", "__spec__",
+    ])

--- a/bindings/python/tree_sitter_sql/__init__.pyi
+++ b/bindings/python/tree_sitter_sql/__init__.pyi
@@ -1,1 +1,10 @@
-def language() -> int: ...
+from typing import Final
+
+# NOTE: uncomment these to include any queries that this grammar contains:
+
+# HIGHLIGHTS_QUERY: Final[str]
+# INJECTIONS_QUERY: Final[str]
+# LOCALS_QUERY: Final[str]
+# TAGS_QUERY: Final[str]
+
+def language() -> object: ...

--- a/bindings/python/tree_sitter_sql/__init__.pyi
+++ b/bindings/python/tree_sitter_sql/__init__.pyi
@@ -2,7 +2,7 @@ from typing import Final
 
 # NOTE: uncomment these to include any queries that this grammar contains:
 
-# HIGHLIGHTS_QUERY: Final[str]
+HIGHLIGHTS_QUERY: Final[str]
 # INJECTIONS_QUERY: Final[str]
 # LOCALS_QUERY: Final[str]
 # TAGS_QUERY: Final[str]

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -12,11 +12,9 @@ fn main() {
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     // NOTE: if your language uses an external scanner, uncomment this block:
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("tree-sitter-sql");
 }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,23 +2,21 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
-    c_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
+    c_config.std("c11").include(src_dir);
+
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
 
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
+    // NOTE: if your language uses an external scanner, uncomment this block:
+    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
 
-    c_config.compile("parser");
-    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("tree-sitter-sql");
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -36,7 +36,7 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "commit-and-tag-version": "^12.0.0",
         "node-gyp": "^10.0.1",
         "prebuildify": "^6.0.0",
-        "tree-sitter-cli": "^0.23.0"
+        "tree-sitter-cli": "^0.24.0"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.0"
@@ -3258,9 +3258,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
-      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.3.tgz",
+      "integrity": "sha512-5vS0SiJf31tMTn9CYLsu5l18qXaw5MLFka3cuGxOB5f4TtgoUSK1Sog6rKmqBc7PvFJq37YcQBjj9giNy2cJPw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "commit-and-tag-version": "^12.0.0",
     "node-gyp": "^10.0.1",
     "prebuildify": "^6.0.0",
-    "tree-sitter-cli": "^0.23.0"
+    "tree-sitter-cli": "^0.24.0"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.0"
@@ -44,20 +44,11 @@
     "url": "https://github.com/derekstride/tree-sitter-sql/issues"
   },
   "homepage": "https://github.com/derekstride/tree-sitter-sql#readme",
-  "tree-sitter": [
-    {
-      "scope": "source.sql",
-      "file-types": [
-        "sql"
-      ],
-      "highlights": [
-        "queries/highlights.scm"
-      ],
-      "indents": [
-        "queries/indents.scm"
-      ]
+  "commit-and-tag-version": {
+    "skip": {
+      "tag": true
     }
-  ],
+  },
   "keywords": [
     "parser",
     "sql"
@@ -69,10 +60,5 @@
     "bindings/node/*",
     "queries/*",
     "src/**"
-  ],
-  "commit-and-tag-version": {
-    "skip": {
-      "tag": true
-    }
-  }
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tree-sitter-sql"
-description = "Sql grammar for tree-sitter"
+description = "Tree-sitter Grammar for SQL"
 version = "0.3.5"
 keywords = ["incremental", "parsing", "tree-sitter", "sql"]
 classifiers = [
@@ -12,18 +12,19 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Topic :: Software Development :: Compilers",
   "Topic :: Text Processing :: Linguistic",
-  "Typing :: Typed"
+  "Typing :: Typed",
 ]
-requires-python = ">=3.8"
+authors = [{ name = "derek stride" }]
+requires-python = ">=3.9"
 license.text = "MIT"
 readme = "README.md"
 
 [project.urls]
-Homepage = "https://github.com/tree-sitter/tree-sitter-sql"
+Homepage = "git+https://github.com/derekstride/tree-sitter-sql.git"
 
 [project.optional-dependencies]
-core = ["tree-sitter~=0.21"]
+core = ["tree-sitter~=0.22"]
 
 [tool.cibuildwheel]
-build = "cp38-*"
+build = "cp39-*"
 build-frontend = "build"

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,8 +1,8 @@
 {
   "grammars": [
     {
-      "name": "@derekstride/sql",
-      "camelcase": "DerekstrideSql",
+      "name": "sql",
+      "camelcase": "SQL",
       "scope": "source.sql",
       "path": ".",
       "file-types": [


### PR DESCRIPTION
needs #279 

changes required to upgrade to tree-sitter 0.24. But it looks like there is at least one issue with a 0.24 upgrade (#282), and upgrading to 0.23 has the advantage of moving Rust bindings to `tree-sitter-language` and simplifying further upgrades there.