### PR TITLE
feat: add `cross join unnest with ordinality`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -294,6 +294,7 @@ module.exports = grammar({
     keyword_out: _ => make_keyword("out"),
     keyword_inout: _ => make_keyword("inout"),
     keyword_variadic: _ => make_keyword("variadic"),
+    keyword_ordinality: _ => make_keyword("ordinality"),
 
     keyword_session: _ => make_keyword("session"),
     keyword_isolation: _ => make_keyword("isolation"),
@@ -3114,10 +3115,25 @@ module.exports = grammar({
       )
     ),
 
-    cross_join: $ => seq(
-      $.keyword_cross,
-      $.keyword_join,
-      $.relation,
+    cross_join: $ => prec.right(
+      seq(
+        $.keyword_cross,
+        $.keyword_join,
+        $.relation,
+        optional(
+          seq(
+            $.keyword_with,
+            $.keyword_ordinality,
+            optional(
+              seq(
+                $.keyword_as,
+                field("alias", $.identifier),
+                paren_list($.identifier),
+              )
+            )
+          )
+        )
+      )
     ),
 
     lateral_join: $ => seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -267,6 +267,7 @@
   (keyword_out)
   (keyword_inout)
   (keyword_variadic)
+  (keyword_ordinality)
   (keyword_session)
   (keyword_isolation)
   (keyword_level)

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -2970,3 +2970,69 @@ FROM (
                 (object_reference
                   (identifier))))))
         (identifier)))))
+
+================================================================================
+SELECT FROM UNNESTED ARRAY WITH ORDINALITY
+================================================================================
+
+SELECT numbers, n, a
+FROM (
+  VALUES
+    (ARRAY[2, 5]),
+    (ARRAY[7, 8, 9])
+) AS x (numbers)
+CROSS JOIN UNNEST(numbers) WITH ORDINALITY AS t (n, a);
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (field
+            (identifier)))
+        (term
+          (field
+            (identifier)))
+        (term
+          (field
+            (identifier)))))
+    (from
+      (keyword_from)
+      (relation
+        (values
+          (keyword_values)
+          (list
+            (array
+              (keyword_array)
+              (literal)
+              (literal)))
+          (list
+            (array
+              (keyword_array)
+              (literal)
+              (literal)
+              (literal))))
+        (keyword_as)
+        (identifier)
+        (list
+          (column
+            (identifier))))
+      (cross_join
+        (keyword_cross)
+        (keyword_join)
+        (relation
+          (invocation
+            (object_reference
+              (identifier))
+            (term
+              (field
+                (identifier)))))
+        (keyword_with)
+        (keyword_ordinality)
+        (keyword_as)
+        (identifier)
+        (identifier)
+        (identifier)))))


### PR DESCRIPTION
Closes #284 

I am not so sure about the alias at the end. 
`relation` can already have an alias, but it does not support this unpacking of arrays. So this compiles, but the resulting AST might be misleading-