### PR TITLE
fix: bump other versions to 0.3.6 and add to docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-sql
-        VERSION "0.3.5"
+        VERSION "0.3.6"
         DESCRIPTION "Tree-sitter Grammar for SQL"
         HOMEPAGE_URL "git+https://github.com/derekstride/tree-sitter-sql.git"
         LANGUAGES C)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ number and preparing for a release. Run the following to generate the release:
 $ npm run release
 ```
 
+Ensure you also bump the version in `tree-sitter.json`, `Cargo.toml`, `pyproject.toml`, & `CMakeLists.txt` before pushing the changes.
+
 Verify that all the changes are correct and push the updates to a new branch.
 
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-sequel"
 description = "Tree-sitter Grammar for SQL"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["derek stride"]
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-sql"
 description = "Tree-sitter Grammar for SQL"
-version = "0.3.5"
+version = "0.3.6"
 keywords = ["incremental", "parsing", "tree-sitter", "sql"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -14,7 +14,7 @@
     }
   ],
   "metadata": {
-    "version": "0.3.5",
+    "version": "0.3.6",
     "license": "MIT",
     "description": "Tree-sitter Grammar for SQL",
     "authors": [


### PR DESCRIPTION
## What

I forgot that we need to manually update the version numbers for some of the other dependencies. I added a mention of it to the CONTRIBUTING.md docs so we don't forget again.