### PR TITLE
build: add CMakeLists.txt to gh-pages build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 20
       - run: npm install
       - name: Publish parser on GitHub Pages
-        run: cp -r LICENSE Cargo.toml src queries bindings Package.swift docs
+        run: cp -r LICENSE CMakeLists.txt Cargo.toml src queries bindings Package.swift docs
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.0


### PR DESCRIPTION
## What

closes #295

Adds the CMakeLists.txt to the files copied to the gh-pages branch.

cc @toge