### PR TITLE
Move tree-sitter-cli to regular dependencies to avoid installation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
   "license": "MIT",
   "dependencies": {
     "node-addon-api": "^7.1.0",
-    "node-gyp-build": "^4.8.0"
+    "node-gyp-build": "^4.8.0",
+    "tree-sitter-cli": "^0.24.0"
   },
   "devDependencies": {
     "commit-and-tag-version": "^12.0.0",
     "node-gyp": "^10.0.1",
-    "prebuildify": "^6.0.0",
-    "tree-sitter-cli": "^0.24.0"
+    "prebuildify": "^6.0.0"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.0"


### PR DESCRIPTION
Move tree-sitter-cli to regular dependencies to avoid installation error

My package json looks like this:
```
...
  "dependencies": {
    "@derekstride/tree-sitter-sql": "^0.3.7",
    "tree-sitter": "^0.21.0"
  }
...
```
When running `npm i` the installation fails because `tree-sitter-sql` is attempting to run this command `"tree-sitter generate && node-gyp-build"`. The `tree-sitter` cli command is not available. In order to avoid this, `tree-sitter-sql` needs to be a regular dependency instead of a `devDependency`

