### PR TITLE
chore: use local tree-sitter bin with npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
-    "install": "tree-sitter generate && node-gyp-build",
-    "prestart": "tree-sitter build --wasm",
-    "start": "tree-sitter playground",
+    "install": "npx tree-sitter generate && node-gyp-build",
+    "prestart": "npx tree-sitter build --wasm",
+    "start": "npx tree-sitter playground",
     "release": "commit-and-tag-version",
     "test": "node --test bindings/node/*_test.js",
     "prebuildify": "prebuildify --napi --strip"


### PR DESCRIPTION
#301 using Node's `npx` runner for in-tree dependency binaries

testing:

- `npm link` in tree-sitter-sql to symlink it to the global folder
- make sure any `tree-sitter` bin on your $path is out of the way

```sh
npm init
npm link @derekstride/tree-sitter-sql --save
npm i --loglevel=verbose
```

```
npm verbose cli /usr/bin/node /usr/bin/npm
npm info using npm@11.0.0
npm info using node@v23.4.0
npm verbose title npm i
npm verbose argv "i" "--loglevel" "verbose"
npm verbose logfile logs-max:10 dir:/home/dian/.npm/_logs/2025-02-04T00_28_27_426Z-
npm verbose logfile /home/dian/.npm/_logs/2025-02-04T00_28_27_426Z-debug-0.log
npm verbose shrinkwrap failed to load node_modules/.package-lock.json missing from lockfile: ../tree-sitter-sql/node_modules/JSONStream
npm info run @derekstride/tree-sitter-sql@0.3.7 install ../tree-sitter-sql npx tree-sitter generate && node-gyp-build
npm http fetch POST 200 https://registry.npmjs.org/-/npm/v1/security/advisories/bulk 379ms
npm info run @derekstride/tree-sitter-sql@0.3.7 install { code: 0, signal: null }

up to date, audited 3 packages in 21s
```

third-last line shows it using the local `tree-sitter` binary; I do have the dev dependencies installed in my tree-sitter-sql directory, so I don't know if this will work with say `npm ci`, but it's good practice anyway.