### PR TITLE
fix: termination of Postgres escape strings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -3534,7 +3534,7 @@ module.exports = grammar({
     // but this is good enough.
     _single_quote_string: _ => seq(/([uU]&)?'([^']|'')*'/, repeat(/'([^']|'')*'/)),
 
-    _postgres_escape_string: _ => /(e|E)'([^']|\')*'/,
+    _postgres_escape_string: _ => /(e|E)'([^']|\\')*'/,
 
     _literal_string: $ => prec(
       1,

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -177,6 +177,29 @@ SELECT E'this is a test';
           (literal))))))
 
 ================================================================================
+Postgres escape string terminates correctly
+================================================================================
+
+SELECT E'this is a test';
+SELECT E'this is another test';
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (literal)))))
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          (literal))))))
+
+================================================================================
 Postgres escape string with literal newlines
 ================================================================================
 


### PR DESCRIPTION
Adds missing `\` to escape the `\` for strings containing `\'`.