### PR TITLE
chore(release): 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [0.3.8](https://github.com/derekstride/tree-sitter-sql/compare/v0.3.7...v0.3.8) (2025-02-10)
+
+
+### Features
+
+* add athena `unload` statement ([b87b5e9](https://github.com/derekstride/tree-sitter-sql/commit/b87b5e95da3e2ea2f32b94dcc5101efac4136a38))
+* include scanner in go bindings ([9d9b968](https://github.com/derekstride/tree-sitter-sql/commit/9d9b968bfddb19bb973483bb594155a38f1428b6))
+* Postgres escape strings ([a0d7b1a](https://github.com/derekstride/tree-sitter-sql/commit/a0d7b1a57a20c46526076261063a3e9b76d7c068))
+
+
+### Bug Fixes
+
+* pyproject url needs http(s)? too ([43510aa](https://github.com/derekstride/tree-sitter-sql/commit/43510aae16c826d0cfa9f956e4bbfed054167b80))
+* repository url needs to be http(s) ([6eae31e](https://github.com/derekstride/tree-sitter-sql/commit/6eae31e2fce9bf8d9ed51283a570112fcb8c64d0))
+* termination of Postgres escape strings ([7583f23](https://github.com/derekstride/tree-sitter-sql/commit/7583f23560a99debc56072205a273eb54b34b439))
+
 ## [0.3.7](https://github.com/derekstride/tree-sitter-sql/compare/v0.3.6...v0.3.7) (2024-11-21)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-sql
-        VERSION "0.3.7"
+        VERSION "0.3.8"
         DESCRIPTION "Tree-sitter Grammar for SQL"
         HOMEPAGE_URL "git+https://github.com/derekstride/tree-sitter-sql.git"
         LANGUAGES C)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ tree-sitter-language = "0.1"
 cc = "~1.2.1"
 
 [dev-dependencies]
-tree-sitter = "0.24.3"
+tree-sitter = "~0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-sequel"
 description = "Tree-sitter Grammar for SQL"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["derek stride"]
 license = "MIT"
 readme = "README.md"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@derekstride/tree-sitter-sql",
-  "version": "0.3.5",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@derekstride/tree-sitter-sql",
-      "version": "0.3.5",
+      "version": "0.3.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,8 +16,7 @@
       "devDependencies": {
         "commit-and-tag-version": "^12.0.0",
         "node-gyp": "^10.0.1",
-        "prebuildify": "^6.0.0",
-        "tree-sitter-cli": "^0.24.0"
+        "prebuildify": "^6.0.0"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.0"
@@ -3255,20 +3254,6 @@
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
-      }
-    },
-    "node_modules/tree-sitter-cli": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.3.tgz",
-      "integrity": "sha512-5vS0SiJf31tMTn9CYLsu5l18qXaw5MLFka3cuGxOB5f4TtgoUSK1Sog6rKmqBc7PvFJq37YcQBjj9giNy2cJPw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "tree-sitter": "cli.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/tree-sitter/node_modules/node-addon-api": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
-    "install": "npx --yes --package=tree-sitter-cli -- tree-sitter generate && node-gyp-build",
-    "prestart": "npx --yes --package=tree-sitter-cli -- tree-sitter build --wasm",
-    "start": "npx --yes --package=tree-sitter-cli -- tree-sitter playground",
+    "install": "npx --yes --package=tree-sitter-cli@v0.24.7 -- tree-sitter generate && node-gyp-build",
+    "prestart": "npx --yes --package=tree-sitter-cli@v0.24.7 -- tree-sitter build --wasm",
+    "start": "npx --yes --package=tree-sitter-cli@v0.24.7 -- tree-sitter playground",
     "release": "commit-and-tag-version",
     "test": "node --test bindings/node/*_test.js",
     "prebuildify": "prebuildify --napi --strip"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derekstride/tree-sitter-sql",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Tree-sitter Grammar for SQL",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-sql"
 description = "Tree-sitter Grammar for SQL"
-version = "0.3.7"
+version = "0.3.8"
 keywords = ["incremental", "parsing", "tree-sitter", "sql"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -14,7 +14,7 @@
     }
   ],
   "metadata": {
-    "version": "0.3.7",
+    "version": "0.3.8",
     "license": "MIT",
     "description": "Tree-sitter Grammar for SQL",
     "authors": [


### PR DESCRIPTION
I had to pin `tree-sitter-cli` to `v0.24.7` in the `npx --package` command because the node bindings [vendor an older version of tree-sitter](https://github.com/tree-sitter/node-tree-sitter/tree/master/vendor). The `v0.25.x` versions are relatively new.