### PR TITLE
feat: select into

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -828,6 +828,12 @@ module.exports = grammar({
     _select_statement: $ => optional_parenthesis(
       seq(
         $.select,
+        optional(
+          seq(
+            $.keyword_into,
+            $.select_expression,
+          ),
+        ),
         optional($.from),
       ),
     ),

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -3036,3 +3036,69 @@ CROSS JOIN UNNEST(numbers) WITH ORDINALITY AS t (n, a);
         (identifier)
         (identifier)
         (identifier)))))
+
+================================================================================
+Simple select into
+================================================================================
+
+SELECT col into alpha FROM my_table;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+              name: (identifier)))))
+    (keyword_into)
+    (select_expression
+      (term
+        value: (field
+            name: (identifier))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          name: (identifier))))))
+
+================================================================================
+Select into multiple vars
+================================================================================
+
+SELECT col1, col2, col3 into alpha, beta, gamma FROM my_table;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (field
+            name: (identifier)))
+        (term
+          value: (field
+            name: (identifier)))
+        (term
+          value: (field
+            name: (identifier)))))
+    (keyword_into)
+    (select_expression
+      (term
+        value: (field
+          name: (identifier)))
+      (term
+        value: (field
+          name: (identifier)))
+      (term
+        value: (field
+          name: (identifier))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          name: (identifier))))))


### PR DESCRIPTION
There's a double usage of this that we won't be able to distinguish easily if at all:

- `select a, b, c into othertable from firsttable` (creates a new table)
- `select a, b, c into alpha, beta, gamma from firsttable` (fills declared variables)

The latter is standard but the former is found in multiple dialects including Postgres and MySQL.