### PR TITLE
Replace number and float pattern

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -35,10 +35,10 @@
 (marginalia) @comment
 
 ((literal) @number
-   (#match? @number "^[-+]?%d+$"))
+   (#match? @number "^[-+]?[0-9]+$"))
 
 ((literal) @float
-  (#match? @float "^[-+]?%d*\.%d*$"))
+  (#match? @float "^[-+]?[0-9]*\.[0-9]*$"))
 
 (parameter) @parameter
 


### PR DESCRIPTION
Hi there. Just wondering, when I try to open any SQL file I'm getting the error:

```
Error in decoration provider "line" (ns=nvim.treesitter.highlighter):
Error executing lua: ...n/neovim/share/nvim/runtime/lua/vim/treesitter/query.lua:452: couldn't parse regex: Vim:E678: Invalid character after %[dxouU]
stack traceback:
        [C]: in function 'regex'
        ...n/neovim/share/nvim/runtime/lua/vim/treesitter/query.lua:452: in function '__index'
        ...n/neovim/share/nvim/runtime/lua/vim/treesitter/query.lua:469: in function 'handler'
        ...n/neovim/share/nvim/runtime/lua/vim/treesitter/query.lua:884: in function '_match_predicates'
        ...n/neovim/share/nvim/runtime/lua/vim/treesitter/query.lua:1013: in function 'iter'
        ...im/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:343: in function 'fn'
        ...im/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:232: in function 'for_each_highlight_state'
        ...im/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:322: in function 'on_line_impl'
        ...im/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:411: in function <...im/share/nvim/runtime/lua/vim/treesit
```

And it looks like the backward slash has been replaced with a percentage symbol here. And if you replace %d with [0-9] for Number and Float then it works good.
p.s. I use vim-dadbod-ui and vim-dadbod-completion plugins and I **don't** use nvim-treesitter plugin, compiled it manually and added to **parser** directory.