### PR TITLE
Include tree-sitter.json in published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "prebuilds/**",
     "bindings/node/*",
     "queries/*",
-    "src/**"
+    "src/**",
+    "tree-sitter.json"
   ]
 }


### PR DESCRIPTION
### Problem
Installing the grammar from npm omits `tree-sitter.json`, making it impossible to build the grammar.

### Fix
Add `tree-sitter.json` to the files field so it's included in the published tarball.