### PR TITLE
feat: add support for backtick-quoted identifiers 

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -3697,6 +3697,7 @@ module.exports = grammar({
       $._double_quote_string,
       $._backtick_quoted_string,
       $._tsql_parameter,
+      seq("`", $._identifier, "`"),
     ),
     _tsql_parameter: $ => seq('@', $._identifier),
     // support nordic chars and umlaue

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -3192,3 +3192,24 @@ SELECT * FROM "table_name";
       (relation
         (object_reference
           name: (identifier))))))
+
+================================================================================
+Select from table with identifiers containing hyphens, dots, or other special characters within backticks
+================================================================================
+
+SELECT * FROM `complex-database.schema_name.table_name`;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (select
+      (keyword_select)
+      (select_expression
+        (term
+          value: (all_fields))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          name: (identifier))))))


### PR DESCRIPTION
Adds support for backtick-quoted identifiers to handle MySQL/MariaDB-style quoted identifiers and BigQuery-style table names with special characters:

```sql
SELECT * FROM `complex-database.schema_name.table_name`
```

Previously failed to parse identifiers containing hyphens, dots, or other special characters within backticks.