### PR TITLE
build: fix tree-sitter/setup-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up the repo
-        uses: tree-sitter/setup-action/cli@v1
+        uses: tree-sitter/setup-action@v2
         with:
           install-lib: false
       - run: tree-sitter generate


### PR DESCRIPTION
## What

CI is broken we need to upgrade the [tree-sitter/setup-action](https://github.com/tree-sitter/setup-action) version