### PR TITLE
feat(grammar): postgres row level security

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -147,6 +147,8 @@ module.exports = grammar({
     keyword_or: _ => make_keyword("or"),
     keyword_is: _ => make_keyword("is"),
     keyword_not: _ => make_keyword("not"),
+    keyword_enable: _ => make_keyword("enable"),
+    keyword_disable: _ => make_keyword("disable"),
     keyword_force: _ => make_keyword("force"),
     keyword_ignore: _ => make_keyword("ignore"),
     keyword_using: _ => make_keyword("using"),
@@ -1792,6 +1794,16 @@ module.exports = grammar({
               $._alter_specifications
             )
           )
+        ),
+        seq(
+          choice(
+            $.keyword_enable,
+            $.keyword_disable,
+            seq(optional($.keyword_no), $.keyword_force),
+          ),
+          $.keyword_row,
+          $.keyword_level,
+          $.keyword_security,
         ),
       ),
     ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -267,6 +267,8 @@
   (keyword_action)
   (keyword_definer)
   (keyword_invoker)
+  (keyword_enable)
+  (keyword_disable)
   (keyword_security)
   (keyword_extension)
   (keyword_version)

--- a/test/corpus/alter.txt
+++ b/test/corpus/alter.txt
@@ -427,6 +427,91 @@ ALTER TABLE my_table
         schema: (identifier)))))
 
 ================================================================================
+Postgres: Alter table and enable row level security
+================================================================================
+
+ALTER TABLE my_table
+  ENABLE ROW LEVEL SECURITY;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (alter_table
+      (keyword_alter)
+      (keyword_table)
+      (object_reference
+        name: (identifier))
+      (keyword_enable)
+      (keyword_row)
+      (keyword_level)
+      (keyword_security))))
+
+================================================================================
+Postgres: Alter table and disable row level security
+================================================================================
+
+ALTER TABLE my_table
+  DISABLE ROW LEVEL SECURITY;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (alter_table
+      (keyword_alter)
+      (keyword_table)
+      (object_reference
+        name: (identifier))
+      (keyword_disable)
+      (keyword_row)
+      (keyword_level)
+      (keyword_security))))
+
+================================================================================
+Postgres: Alter table and force row level security
+================================================================================
+
+ALTER TABLE my_table
+  FORCE ROW LEVEL SECURITY;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (alter_table
+      (keyword_alter)
+      (keyword_table)
+      (object_reference
+        name: (identifier))
+      (keyword_force)
+      (keyword_row)
+      (keyword_level)
+      (keyword_security))))
+
+================================================================================
+Postgres: Alter table and no force row level security
+================================================================================
+
+ALTER TABLE my_table
+  NO FORCE ROW LEVEL SECURITY;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (alter_table
+      (keyword_alter)
+      (keyword_table)
+      (object_reference
+        name: (identifier))
+      (keyword_no)
+      (keyword_force)
+      (keyword_row)
+      (keyword_level)
+      (keyword_security))))
+
+================================================================================
 Alter table and change owner
 ================================================================================
 


### PR DESCRIPTION
### Summary

Support `[ENABLE / DISABLE / FORCE / NO FORCE] ROW LEVEL SECURITY`, an `ALTER TABLE` command Postgres added in [release 9.5](https://www.postgresql.org/docs/9.5/release-9-5.html).

Adds two new keywords:

* `keyword_enable`
* `keyword_disable`

Adds one new branch to the `alter_table` grammar rule.

### Current behavior:

```sh
tree-sitter generate && echo 'ALTER TABLE my_table ENABLE ROW LEVEL SECURITY;' | tree-sitter parse
```

```text
(program [0, 0] - [1, 0]
  (statement [0, 0] - [0, 31]
    (alter_table [0, 0] - [0, 31]
      (keyword_alter [0, 0] - [0, 5])
      (keyword_table [0, 6] - [0, 11])
      (object_reference [0, 12] - [0, 20]
        name: (identifier [0, 12] - [0, 20]))
      (add_column [0, 21] - [0, 31]
        (column_definition [0, 21] - [0, 31]
          name: (identifier [0, 21] - [0, 27])
          custom_type: (object_reference [0, 28] - [0, 31]
            name: (identifier [0, 28] - [0, 31]))))))
  (ERROR [0, 32] - [0, 46]
    (keyword_security [0, 38] - [0, 46])))
```

### Behavior after this change:

```text
(program [0, 0] - [1, 0]
  (statement [0, 0] - [0, 46]
    (alter_table [0, 0] - [0, 46]
      (keyword_alter [0, 0] - [0, 5])
      (keyword_table [0, 6] - [0, 11])
      (object_reference [0, 12] - [0, 20]
        name: (identifier [0, 12] - [0, 20]))
      (keyword_enable [0, 21] - [0, 27])
      (keyword_row [0, 28] - [0, 31])
      (keyword_level [0, 32] - [0, 37])
      (keyword_security [0, 38] - [0, 46]))))
```

### Test this change:

```sh
git fetch && git switch mp/row-level-security

tree-sitter generate && tree-sitter test
```

### Issue link:

https://github.com/DerekStride/tree-sitter-sql/issues/345