### PR TITLE
fix minor window function corpus test

### DIFF
--- a/test/corpus/window_functions.txt
+++ b/test/corpus/window_functions.txt
@@ -201,7 +201,7 @@ Window Functions two inline functions
 SELECT
   a,
   SUM(b) OVER (PARTITION BY c) AS w1,
-  AVG(b) OVER (ORDER BY d) AS w2,
+  AVG(b) OVER (ORDER BY d) AS w2
 FROM tab1;
 
 --------------------------------------------------------------------------------
@@ -248,11 +248,12 @@ FROM tab1;
                   (field
                     name: (identifier))))))
           (keyword_as)
-          alias: (identifier))
-        (term
-          value: (field
-            name: (identifier))
-          alias: (identifier))))))
+          alias: (identifier))))
+    (from
+      (keyword_from)
+      (relation
+        (object_reference
+          name: (identifier))))))
 
 ================================================================================
 Window Functions separate definition


### PR DESCRIPTION
I'm designing a new language to be a superset of SQL and found this test which checks parse output for invalid SQL (which "should" be undefined).

I fixed it by fixing the syntax in the SQL query itself and running `tree-sitter test --update` to update the parse tree. It now correctly parses `FROM tab1` as a `(from ...)` node instead of another column whose expression is `FROM` and whose alias is `tab1`. 🙂 