### PR TITLE
fix(scanner): don't leak start_tag across serialize/deserialize

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -170,19 +170,21 @@ unsigned tree_sitter_sql_external_scanner_serialize(void *payload, char *buffer)
   }
 
   memcpy(buffer, state->start_tag, tag_length);
-  if (state->start_tag != NULL) {
-    free(state->start_tag);
-    state->start_tag = NULL;
-  }
   return tag_length;
 }
 
 void tree_sitter_sql_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
   LexerState *state = (LexerState *)payload;
-  state->start_tag = NULL;
+  if (state->start_tag != NULL) {
+    free(state->start_tag);
+    state->start_tag = NULL;
+  }
   // A length of 1 can't exists.
   if (length > 1) {
     state->start_tag = malloc(length);
+    if (state->start_tag == NULL) {
+      return;
+    }
     memcpy(state->start_tag, buffer, length);
   }
 }

--- a/test/corpus/procedures.txt
+++ b/test/corpus/procedures.txt
@@ -60,6 +60,67 @@ $$;
         (dollar_quote)))))
 
 ================================================================================
+Procedure with named tag dollar-quote (PostgreSQL)
+================================================================================
+
+CREATE PROCEDURE insert_data(a integer, b integer)
+LANGUAGE SQL
+AS $body$
+BEGIN
+INSERT INTO tbl VALUES (a);
+INSERT INTO tbl VALUES (b);
+END;
+$body$;
+
+--------------------------------------------------------------------------------
+
+(program
+  (statement
+    (create_procedure
+      (keyword_create)
+      (keyword_procedure)
+      (object_reference
+        name: (identifier))
+      (function_arguments
+        (function_argument
+          (identifier)
+          (int
+            (keyword_int)))
+        (function_argument
+          (identifier)
+          (int
+            (keyword_int))))
+      (function_language
+        (keyword_language)
+        (identifier))
+      (procedure_body
+        (keyword_as)
+        (dollar_quote)
+        (keyword_begin)
+        (statement
+          (insert
+            (keyword_insert)
+            (keyword_into)
+            (object_reference
+              name: (identifier))
+            (keyword_values)
+            (list
+              (field
+                name: (identifier)))))
+        (statement
+          (insert
+            (keyword_insert)
+            (keyword_into)
+            (object_reference
+              name: (identifier))
+            (keyword_values)
+            (list
+              (field
+                name: (identifier)))))
+        (keyword_end)
+        (dollar_quote)))))
+
+================================================================================
 Procedure with OR REPLACE (PostgreSQL)
 ================================================================================
 


### PR DESCRIPTION
## Problem

I was running macOS `leaks` on a long-running host that parses many `.sql` files and noticed a growing set of allocations rooted in `tree_sitter_sql_external_scanner_deserialize` that grew linearly with the number of parses. 

I think the external scanner's `_serialize`/`_deserialize` pair mishandles the `LexerState.start_tag` for strings delimited by dollar-sign tags instead of quotes:

* `_serialize` frees and nulls `start_tag` after copying it into the snapshot buffer. If tree-sitter calls `scan()` on the same scanner instance again, it sees a NULL `start_tag` and can no longer match the pending dollar-quoted-string end tag.
* `_deserialize` assigns to `start_tag` without freeing whatever the state already owns, leaking the previous allocation every time saved state is restored.

## Solution

Free any existing `start_tag` at the top of `_deserialize` instead of `_serialize`, using the same pattern as `_destroy`.

## Testing

After this fix, running `leaks` on the same program shows no more live allocations from `tree_sitter_sql_external_scanner_deserialize`.

I added a corpus entry to assert the AST shape and guard the named-tag parse against future regressions. It produces the same AST as the previous test, but uses named tags (`$body$ ... $body$` instead of `$$`...`$$`).
